### PR TITLE
Update .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -31,6 +31,14 @@ AllowShortLoopsOnASingleLine: false
 PointerAlignment: Right
 AlignTrailingComments: true
 NamespaceIndentation: All
+AlignConsecutiveAssignments: true
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: ENAS_Left
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AlignConsecutiveDeclarations: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
 
 SpaceAfterCStyleCast: true
 CommentPragmas: '^ NO-FORMAT:'


### PR DESCRIPTION
This PR adds (but does not modify) clang-format rules. I've made it to closely match the style gsb uses. 

P.S. I'm planning to format everything again before beta-10 releases