### PR TITLE
Enhance undo/redo queue to support room-specific undo/redo, and level-wide undo/redo

### DIFF
--- a/Operation.cpp
+++ b/Operation.cpp
@@ -226,7 +226,7 @@ void BackTrackOperation(struct OperationParams *operation)
 /// <param name="operationIdx">
 /// The operation indexer to modify.
 /// </param>
-static void ExecuteOperationImpl(struct OperationParams *operation, std::deque<struct OperationParams *> operationHist, unsigned int *operationIdx)
+static void ExecuteOperationImpl(struct OperationParams *operation, std::deque<struct OperationParams *> &operationHist, unsigned int *operationIdx)
 {
     PerformOperation(operation);
     // If we perform an action after a series of undo, then delete the "undone" operations from history
@@ -253,7 +253,6 @@ void ExecuteOperation(struct OperationParams *operation)
 {
     int currentRoomNumber = singleton->GetCurrentRoom()->GetRoomID();
     ExecuteOperationImpl(operation, operationHistory[currentRoomNumber], operationIndex + currentRoomNumber);
-    // TODO: When we modify operation history, then try to undo it, the history deque is empty in the unod function. Fix this before merging to master.
 }
 
 /// <summary>
@@ -283,12 +282,12 @@ void ExecuteOperationGlobal(struct OperationParams *operation)
 /// <param name="operationIdx">
 /// The operation indexer to modify.
 /// </param>
-static void UndoOperationImpl(std::deque<struct OperationParams *> operationHist, unsigned int *operationIdx)
+static void UndoOperationImpl(std::deque<struct OperationParams *> &operationHist, unsigned int *operationIdx)
 {
     // We cannot undo past the end of the deque
     if (*operationIdx < operationHist.size())
     {
-        BackTrackOperation(operationHist[*operationIdx++]);
+        BackTrackOperation(operationHist[(*operationIdx)++]);
 
         // If the entire operation history is undone for all rooms, then there are no unsaved changes
         for (unsigned int i = 0; i < sizeof(operationIndex) / sizeof(operationIndex[0]); ++i)
@@ -346,7 +345,7 @@ void UndoOperationGlobal()
 /// <param name="operationIdx">
 /// The operation indexer to modify.
 /// </param>
-static void RedoOperationImpl(std::deque<struct OperationParams *> operationHist, unsigned int *operationIdx)
+static void RedoOperationImpl(std::deque<struct OperationParams *> &operationHist, unsigned int *operationIdx)
 {
     // We cannot redo past the front of the deque
     if (*operationIdx)

--- a/Operation.cpp
+++ b/Operation.cpp
@@ -7,9 +7,9 @@ extern WL4EditorWindow *singleton;
 
 // Globals used by the undo system
 static std::deque<struct OperationParams *> operationHistory[16];
-static unsigned int operationIndex[16];
+static unsigned int operationIndex[16]; // For room-specific changes
 static std::deque<struct OperationParams *> operationHistoryGlobal;
-static unsigned int operationIndexGlobal;
+static unsigned int operationIndexGlobal; // For level-wide changes
 
 /// <summary>
 /// Perform an operation based on its parameters.
@@ -233,7 +233,7 @@ static void ExecuteOperationImpl(struct OperationParams *operation, std::deque<s
     while (*operationIdx)
     {
         // Delete the front operation in the queue while decrementing the operation index until the index reaches 0
-        --*operationIdx;
+        --(*operationIdx);
         struct OperationParams *frontOP = operationHist[0];
         delete frontOP;
         operationHist.pop_front();
@@ -350,7 +350,7 @@ static void RedoOperationImpl(std::deque<struct OperationParams *> &operationHis
     // We cannot redo past the front of the deque
     if (*operationIdx)
     {
-        PerformOperation(operationHist[--*operationIdx]);
+        PerformOperation(operationHist[--(*operationIdx)]);
 
         // Performing a "redo" will make unsaved changes
         singleton->SetUnsavedChanges(true);

--- a/Operation.cpp
+++ b/Operation.cpp
@@ -8,6 +8,8 @@ extern WL4EditorWindow *singleton;
 // Globals used by the undo system
 static std::deque<struct OperationParams *> operationHistory[16];
 static unsigned int operationIndex[16];
+static std::deque<struct OperationParams *> operationHistoryGlobal;
+static unsigned int operationIndexGlobal;
 
 /// <summary>
 /// Perform an operation based on its parameters.
@@ -218,22 +220,52 @@ void BackTrackOperation(struct OperationParams *operation)
 /// <param name="operation">
 /// The operation to perform.
 /// </param>
+/// <param name="operationHist">
+/// The the history deque from which to execute an operation.
+/// </param>
+/// <param name="operationIdx">
+/// The operation indexer to modify.
+/// </param>
+static void ExecuteOperationImpl(struct OperationParams *operation, std::deque<struct OperationParams *> operationHist, unsigned int *operationIdx)
+{
+    PerformOperation(operation);
+    // If we perform an action after a series of undo, then delete the "undone" operations from history
+    while (*operationIdx)
+    {
+        // Delete the front operation in the queue while decrementing the operation index until the index reaches 0
+        --*operationIdx;
+        struct OperationParams *frontOP = operationHist[0];
+        delete frontOP;
+        operationHist.pop_front();
+    }
+    operationHist.push_front(operation);
+    singleton->SetUnsavedChanges(true);
+}
+
+/// <summary>
+/// Perform an operation based on its parameters, and add it to the undo deque.
+/// This is for performing an operation within a Room.
+/// </summary>
+/// <param name="operation">
+/// The operation to perform.
+/// </param>
 void ExecuteOperation(struct OperationParams *operation)
 {
     int currentRoomNumber = singleton->GetCurrentRoom()->GetRoomID();
+    ExecuteOperationImpl(operation, operationHistory[currentRoomNumber], operationIndex + currentRoomNumber);
+    // TODO: When we modify operation history, then try to undo it, the history deque is empty in the unod function. Fix this before merging to master.
+}
 
-    PerformOperation(operation);
-    // If we perform an action after a series of undo, then delete the "undone" operations from history
-    while (operationIndex[currentRoomNumber])
-    {
-        // Delete the front operation in the queue while decrementing the operation index until the index reaches 0
-        --operationIndex[currentRoomNumber];
-        struct OperationParams *frontOP = operationHistory[currentRoomNumber][0];
-        delete frontOP;
-        operationHistory[currentRoomNumber].pop_front();
-    }
-    operationHistory[currentRoomNumber].push_front(operation);
-    singleton->SetUnsavedChanges(true);
+/// <summary>
+/// Perform an operation based on its parameters, and add it to the undo deque.
+/// This is for performing a global operation.
+/// </summary>
+/// <param name="operation">
+/// The operation to perform.
+/// </param>
+void ExecuteOperationGlobal(struct OperationParams *operation)
+{
+    ExecuteOperationImpl(operation, operationHistoryGlobal, &operationIndexGlobal);
 }
 
 /// <summary>
@@ -244,19 +276,24 @@ void ExecuteOperation(struct OperationParams *operation)
 /// Instead, an index is used within the deque to track which operation should be undone next.
 /// That way, an operation can be undone and redone multiple times.
 /// </remarks>
-void UndoOperation()
+/// </param>
+/// <param name="operationHist">
+/// The the history deque from which to undo an operation.
+/// </param>
+/// <param name="operationIdx">
+/// The operation indexer to modify.
+/// </param>
+static void UndoOperationImpl(std::deque<struct OperationParams *> operationHist, unsigned int *operationIdx)
 {
-    int currentRoomNumber = singleton->GetCurrentRoom()->GetRoomID();
-
     // We cannot undo past the end of the deque
-    if (operationIndex[currentRoomNumber] < operationHistory[currentRoomNumber].size())
+    if (*operationIdx < operationHist.size())
     {
-        BackTrackOperation(operationHistory[currentRoomNumber][operationIndex[currentRoomNumber]++]);
+        BackTrackOperation(operationHist[*operationIdx++]);
 
         // If the entire operation history is undone for all rooms, then there are no unsaved changes
         for (unsigned int i = 0; i < sizeof(operationIndex) / sizeof(operationIndex[0]); ++i)
         {
-            if (operationIndex[currentRoomNumber] != operationHistory[currentRoomNumber].size())
+            if (*operationIdx != operationHist.size())
             {
                 return;
             }
@@ -267,7 +304,63 @@ void UndoOperation()
 }
 
 /// <summary>
+/// Undo a previously performed operation in the undo deque.
+/// This is for undoing an operation within a Room.
+/// </summary>
+/// <remarks>
+/// This function does not remove the operation from the deque.
+/// Instead, an index is used within the deque to track which operation should be undone next.
+/// That way, an operation can be undone and redone multiple times.
+/// </remarks>
+void UndoOperation()
+{
+    int currentRoomNumber = singleton->GetCurrentRoom()->GetRoomID();
+    UndoOperationImpl(operationHistory[currentRoomNumber], operationIndex + currentRoomNumber);
+}
+
+/// <summary>
+/// Undo a previously performed operation in the undo deque.
+/// This is for undoing a global operation.
+/// </summary>
+/// <remarks>
+/// This function does not remove the operation from the deque.
+/// Instead, an index is used within the deque to track which operation should be undone next.
+/// That way, an operation can be undone and redone multiple times.
+/// </remarks>
+void UndoOperationGlobal()
+{
+    UndoOperationImpl(operationHistoryGlobal, &operationIndexGlobal);
+}
+
+/// <summary>
 /// Redo a previously undone operation from the undo deque.
+/// </summary>
+/// <remarks>
+/// This function does not add the operation to the deque.
+/// Instead, an index is used within the deque to track which operation should be redone next.
+/// That way, an operation can be undone and redone multiple times.
+/// </remarks>
+/// <param name="operationHist">
+/// The the history deque from which to undo an operation.
+/// </param>
+/// <param name="operationIdx">
+/// The operation indexer to modify.
+/// </param>
+static void RedoOperationImpl(std::deque<struct OperationParams *> operationHist, unsigned int *operationIdx)
+{
+    // We cannot redo past the front of the deque
+    if (*operationIdx)
+    {
+        PerformOperation(operationHist[--*operationIdx]);
+
+        // Performing a "redo" will make unsaved changes
+        singleton->SetUnsavedChanges(true);
+    }
+}
+
+/// <summary>
+/// Redo a previously undone operation from the undo deque.
+/// This is for redoing an operation within a Room.
 /// </summary>
 /// <remarks>
 /// This function does not add the operation to the deque.
@@ -277,15 +370,21 @@ void UndoOperation()
 void RedoOperation()
 {
     int currentRoomNumber = singleton->GetCurrentRoom()->GetRoomID();
+    RedoOperationImpl(operationHistory[currentRoomNumber], operationIndex + currentRoomNumber);
+}
 
-    // We cannot redo past the front of the deque
-    if (operationIndex[currentRoomNumber])
-    {
-        PerformOperation(operationHistory[currentRoomNumber][--operationIndex[currentRoomNumber]]);
-
-        // Performing a "redo" will make unsaved changes
-        singleton->SetUnsavedChanges(true);
-    }
+/// <summary>
+/// Redo a previously undone operation from the undo deque.
+/// This is for redoing a global operation.
+/// </summary>
+/// <remarks>
+/// This function does not add the operation to the deque.
+/// Instead, an index is used within the deque to track which operation should be redone next.
+/// That way, an operation can be undone and redone multiple times.
+/// </remarks>
+void RedoOperationGlobal()
+{
+    RedoOperationImpl(operationHistoryGlobal, &operationIndexGlobal);
 }
 
 /// <summary>
@@ -306,6 +405,14 @@ void ResetUndoHistory()
         operationHistory[i].clear();
     }
 
+    // Deconstruct the global history
+    for (unsigned int j = 0; j < operationHistoryGlobal.size(); ++j)
+    {
+        delete operationHistoryGlobal[j];
+    }
+    operationHistoryGlobal.clear();
+
     // Re-initialize all the operation indexes to zero
     memset(operationIndex, 0, sizeof(operationIndex));
+    operationIndexGlobal = 0;
 }

--- a/Operation.h
+++ b/Operation.h
@@ -124,10 +124,13 @@ struct OperationParams
 
 // Operation function prototypes
 void ExecuteOperation(struct OperationParams *operation);
+void ExecuteOperationGlobal(struct OperationParams *operation);
 void PerformOperation(struct OperationParams *operation);
 void BackTrackOperation(struct OperationParams *operation);
 void UndoOperation();
+void UndoOperationGlobal();
 void RedoOperation();
+void RedoOperationGlobal();
 void ResetUndoHistory();
 
 

--- a/WL4EditorWindow.cpp
+++ b/WL4EditorWindow.cpp
@@ -13,6 +13,7 @@
 #include <QGraphicsScene>
 #include <QMessageBox>
 #include <QTextEdit>
+#include <QSizePolicy>
 
 bool LoadROMFile(QString); // Prototype for main.cpp function
 
@@ -254,13 +255,13 @@ void WL4EditorWindow::LoadROMDataFromFile(QString qFilePath)
 /// </param>
 void WL4EditorWindow::PrintMousePos(uint x, uint y)
 {
-    bool condition;
+    bool mouseInTileArea;
     if(CurrentLevel->GetRooms()[selectedRoom]->GetLayer0MappingParam()) {
-        condition = (x >= CurrentLevel->GetRooms()[selectedRoom]->GetLayer0Width()) || (y >= CurrentLevel->GetRooms()[selectedRoom]->GetLayer0Height());
+        mouseInTileArea = (x >= CurrentLevel->GetRooms()[selectedRoom]->GetLayer0Width()) || (y >= CurrentLevel->GetRooms()[selectedRoom]->GetLayer0Height());
     } else {
-        condition = (x >= CurrentLevel->GetRooms()[selectedRoom]->GetWidth()) || (y >= CurrentLevel->GetRooms()[selectedRoom]->GetHeight());
+        mouseInTileArea = (x >= CurrentLevel->GetRooms()[selectedRoom]->GetWidth()) || (y >= CurrentLevel->GetRooms()[selectedRoom]->GetHeight());
     }
-    if(condition)
+    if(mouseInTileArea)
         statusBarLabel_MousePosition->setText("Out of range!");
     else
         statusBarLabel_MousePosition->setText("(" + QString::number(x) + ", " + QString::number(y) + ")");
@@ -291,7 +292,9 @@ void WL4EditorWindow::UIStartUp(int currentTilesetID)
         ui->menu_clear_Entity_list->setEnabled(true);
         ui->actionClear_all->setEnabled(true);
         ui->actionRedo->setEnabled(true);
+        ui->actionRedo_global->setEnabled(true);
         ui->actionUndo->setEnabled(true);
+        ui->actionUndo_global->setEnabled(true);
         ui->actionRun_from_file->setEnabled(true);
 
         // Load Dock widget
@@ -1134,7 +1137,6 @@ void WL4EditorWindow::resizeEvent(QResizeEvent *event)
 /// </summary>
 void WL4EditorWindow::on_actionUndo_triggered()
 {
-    EditModeWidget->UncheckHiddencoinsViewCheckbox();
     UndoOperation();
 }
 
@@ -1143,8 +1145,23 @@ void WL4EditorWindow::on_actionUndo_triggered()
 /// </summary>
 void WL4EditorWindow::on_actionRedo_triggered()
 {
-    EditModeWidget->UncheckHiddencoinsViewCheckbox();
     RedoOperation();
+}
+
+/// <summary>
+/// Undo one step of gobal history.
+/// </summary>
+void WL4EditorWindow::on_actionUndo_global_triggered()
+{
+    UndoOperationGlobal();
+}
+
+/// <summary>
+/// Redo one step of gobal history.
+/// </summary>
+void WL4EditorWindow::on_actionRedo_global_triggered()
+{
+    RedoOperationGlobal();
 }
 
 /// <summary>
@@ -1196,7 +1213,7 @@ void WL4EditorWindow::on_actionEdit_Tileset_triggered()
         operation->TilesetChange = true;
         operation->lastTilesetEditParams = _oldRoomTilesetEditParams;
         operation->newTilesetEditParams = _currentRoomTilesetEditParams;
-        ExecuteOperation(operation); // Set UnsavedChanges bool inside
+        ExecuteOperationGlobal(operation); // Set UnsavedChanges bool inside
     }
     else
     {

--- a/WL4EditorWindow.h
+++ b/WL4EditorWindow.h
@@ -137,6 +137,8 @@ private slots:
     void on_actionRun_from_file_triggered();
     void on_actionOutput_window_triggered();
     void on_actionClear_all_triggered();
+    void on_actionUndo_global_triggered();
+    void on_actionRedo_global_triggered();
 };
 
 #endif // WL4EDITORWINDOW_H

--- a/WL4EditorWindow.ui
+++ b/WL4EditorWindow.ui
@@ -126,7 +126,7 @@
      <x>0</x>
      <y>0</y>
      <width>1900</width>
-     <height>23</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -228,6 +228,8 @@
     </widget>
     <addaction name="actionUndo"/>
     <addaction name="actionRedo"/>
+    <addaction name="actionUndo_global"/>
+    <addaction name="actionRedo_global"/>
     <addaction name="separator"/>
     <addaction name="actionLevel_Config"/>
     <addaction name="actionRoom_Config"/>
@@ -481,6 +483,28 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Del</string>
+   </property>
+  </action>
+  <action name="actionUndo_global">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Undo (global)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+Z</string>
+   </property>
+  </action>
+  <action name="actionRedo_global">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Redo (global)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+Y</string>
    </property>
   </action>
  </widget>

--- a/main.cpp
+++ b/main.cpp
@@ -98,7 +98,6 @@ int main(int argc, char *argv[])
         window.LoadROMDataFromFile(filePath);
     }
     testFile.close();
-    testFile.remove();
 
     //-------------------------------------------------------------------
 


### PR DESCRIPTION
This is to support the separation of room-specific operations such as:

- Change a tile
- Change the camera settings
- Move entities

From level-wide operations such as:

- Change the level name
- Modify the tileset
- Modify the doors