### PR TITLE
Fix patchoffset at beginning of hook string

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+beta-11:
+- Fix that you could not provide a hook string with the patch address identifier "P" at the beginning of the string
+
 beta-10:
 (major changes)
 - Add patch manager feature which allows you to add or remove patches, ranging from simple hex edits to custom C code called from an asm hook.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 beta-11:
+- Added more script interface API functions
+- Support importing and exporting palette files in the tileset editor
+- Fix updating the palette does not update the graphicsview in the tileset editor
 - Fix that you could not provide a hook string with the patch address identifier "P" at the beginning of the string
 
 beta-10:

--- a/Dialog/PatchEditDialog.cpp
+++ b/Dialog/PatchEditDialog.cpp
@@ -83,7 +83,7 @@ static unsigned int GetPatchOffset(QString str)
 {
     str = str.replace(" ", "").toUpper();
     int index = str.indexOf("P");
-    return index > 0 ? index / 2 : -1;
+    return index >= 0 ? index / 2 : -1;
 }
 
 /// <summary>

--- a/WL4Constants.h
+++ b/WL4Constants.h
@@ -1,7 +1,7 @@
 #ifndef WL4CONSTANTS_H
 #define WL4CONSTANTS_H
 
-#define WL4EDITOR_VERSION "beta-10"
+#define WL4EDITOR_VERSION "beta-11"
 
 namespace WL4Constants
 {


### PR DESCRIPTION
Fix that you could not provide a hook string with the patch address identifier "P" at the beginning of the string