### PR TITLE
Fix Rectangle select mode can disable switching rooms

### DIFF
--- a/EditorWindow/MainGraphicsView.cpp
+++ b/EditorWindow/MainGraphicsView.cpp
@@ -1,7 +1,6 @@
 ﻿#include "MainGraphicsView.h"
 #include "WL4EditorWindow.h"
 #include "Operation.h"
-#include "MainGraphicsView.h"
 
 #include <QMessageBox>
 #include <QMouseEvent>

--- a/EditorWindow/MainGraphicsView.cpp
+++ b/EditorWindow/MainGraphicsView.cpp
@@ -1,6 +1,7 @@
 ﻿#include "MainGraphicsView.h"
 #include "WL4EditorWindow.h"
 #include "Operation.h"
+#include "MainGraphicsView.h"
 
 #include <QMessageBox>
 #include <QMouseEvent>
@@ -65,7 +66,6 @@ void MainGraphicsView::mousePressEvent(QMouseEvent *event)
                 if (event->button() == Qt::LeftButton)
                 {
                     if(!singleton->Getgraphicview()->scene()) return;
-                    singleton->SetChangeCurrentRoomEnabled(false);
 
                     if(has_a_rect)
                     {
@@ -73,14 +73,8 @@ void MainGraphicsView::mousePressEvent(QMouseEvent *event)
                         if(tileX < rectx || tileX > (rectx + rectwidth - 1) ||
                                 tileY < recty || tileY > (recty + rectheight - 1))
                         {
-                            if(rect != nullptr)
-                            {
-                                delete rect; rect = nullptr;
-                            }
-                            if(selectedrectgraphic != nullptr)
-                            {
-                                delete selectedrectgraphic; selectedrectgraphic = nullptr;
-                            }
+
+                            ResetRectPixmaps();
                             has_a_rect = false;
 
                             // Do Operation (and update layer data)
@@ -109,13 +103,7 @@ void MainGraphicsView::mousePressEvent(QMouseEvent *event)
                             }
                             ExecuteOperation(params);
                             // Reset variables
-                            rectx = recty = -1;
-                            tmpLTcornerTileX = rectselectstartTileX = tmpLTcornerTileY = rectselectstartTileY = -1;
-                            rectwidth = rectheight = 0;
-                            has_a_rect = false;
-                            dragInitmouseX = dragInitmouseY = -1;
-                            rectdata.clear();
-                            singleton->SetChangeCurrentRoomEnabled(true);
+                            ResetRect();
                             return;
                         }
 
@@ -801,21 +789,8 @@ void MainGraphicsView::keyPressEvent(QKeyEvent *event)
                         ExecuteOperation(params);
                     }
                     // Reset variables
-                    if(rect != nullptr)
-                    {
-                        delete rect; rect = nullptr;
-                    }
-                    if(selectedrectgraphic != nullptr)
-                    {
-                        delete selectedrectgraphic; selectedrectgraphic = nullptr;
-                    }
-                    rectx = recty = -1;
-                    tmpLTcornerTileX = tmpLTcornerTileY = rectselectstartTileX = rectselectstartTileY = -1;
-                    rectwidth = rectheight = 0;
-                    has_a_rect = false;
-                    dragInitmouseX = dragInitmouseY = -1;
-                    rectdata.clear();
-                    singleton->SetChangeCurrentRoomEnabled(true);
+                    ResetRectPixmaps();
+                    ResetRect();
                     return;
                 }
             }
@@ -841,6 +816,15 @@ void MainGraphicsView::SetRectSelectMode(bool state)
 {
     rectSelectMode = state;
     singleton->RefreshRectSelectHint(rectSelectMode);
+    ResetRectPixmaps();
+    ResetRect();
+}
+
+
+/// <summary>
+/// This function will reset rectangle selection pixmaps variables if needed
+/// </summary>
+void MainGraphicsView::ResetRectPixmaps() {
     if(rect != nullptr)
     {
         delete rect;
@@ -851,7 +835,13 @@ void MainGraphicsView::SetRectSelectMode(bool state)
         delete selectedrectgraphic;
         selectedrectgraphic = nullptr;
     }
-    // Reset variables
+}
+
+/// <summary>
+/// This function will reset rectangle selection variables (but it doesn't reset the rect graphics)
+/// </summary>
+void MainGraphicsView::ResetRect() {
+    Isdraggingrect=false;
     rectx = recty = -1;
     tmpLTcornerTileX = tmpLTcornerTileY = rectselectstartTileX = rectselectstartTileY = -1;
     rectwidth = rectheight = 0;

--- a/EditorWindow/MainGraphicsView.h
+++ b/EditorWindow/MainGraphicsView.h
@@ -20,7 +20,8 @@ public:
     void DeselectDoorAndEntity(bool updateRenderArea = false);
     void SetRectSelectMode(bool state);
     void ClearRectPointer() { rect = nullptr; }
-
+    void ResetRect();
+    void ResetRectPixmaps();
 private:
     int SelectedDoorID = -1;
     int SelectedEntityID = -1;

--- a/WL4EditorWindow.cpp
+++ b/WL4EditorWindow.cpp
@@ -387,6 +387,8 @@ void WL4EditorWindow::SetCurrentRoomId(int roomid)
     // SetRectSelectMode(ui->actionRect_Select_Mode->isChecked());
     // Deselect Door and Entity
     ui->graphicsView->DeselectDoorAndEntity(true);
+    ui->graphicsView->ResetRectPixmaps();
+    ui->graphicsView->ResetRect();
 
     // Load the previous room
     selectedRoom = roomid;
@@ -1301,6 +1303,8 @@ void WL4EditorWindow::on_roomDecreaseButton_clicked()
     // SetRectSelectMode(ui->actionRect_Select_Mode->isChecked());
     // Deselect Door and Entity
     ui->graphicsView->DeselectDoorAndEntity(true);
+    ui->graphicsView->ResetRectPixmaps();
+    ui->graphicsView->ResetRect();
 
     // Load the previous room
     --selectedRoom;
@@ -1327,6 +1331,8 @@ void WL4EditorWindow::on_roomIncreaseButton_clicked()
     // SetRectSelectMode(ui->actionRect_Select_Mode->isChecked());
     // Deselect Door and Entity
     ui->graphicsView->DeselectDoorAndEntity(true);
+    ui->graphicsView->ResetRectPixmaps();
+    ui->graphicsView->ResetRect();
 
     // Load the next room
     ++selectedRoom;


### PR DESCRIPTION
Fix #359
Add ResetRect() and ResetRectPixmaps() in MainGraphicsView to avoid code duplication