### PR TITLE
Bugfixes 20210421

### DIFF
--- a/Dialog/RoomConfigDialog.cpp
+++ b/Dialog/RoomConfigDialog.cpp
@@ -506,11 +506,11 @@ void RoomConfigDialog::on_spinBox_Layer0MappingType_valueChanged(int arg1)
     case 0x22: ui->label_CurLayer0MappingType->setText("Tile8x8 & autoscroll"); break;
     }
 
+    int BGptr = ui->ComboBox_BGLayerPicker->currentText().toUInt(nullptr, 16);
+    int L0ptr = ui->ComboBox_Layer0Picker->currentText().toUInt(nullptr, 16);
     if (arg1 >= LevelComponents::LayerMap16) // Enable L0
     {
         ui->CheckBox_Layer0Alpha->setEnabled(true);
-        int BGptr = ui->ComboBox_BGLayerPicker->currentText().toUInt(nullptr, 16);
-        int L0ptr = ui->ComboBox_Layer0Picker->currentText().toUInt(nullptr, 16);
         if(arg1 >= LevelComponents::LayerMap16 && arg1 < LevelComponents::LayerTile8x8) // Map16
         {
             ui->spinBox_Layer0Width->setEnabled(true);
@@ -524,11 +524,14 @@ void RoomConfigDialog::on_spinBox_Layer0MappingType_valueChanged(int arg1)
             ui->spinBox_Layer0Height->setEnabled(false);
             ui->ComboBox_Layer0Picker->setEnabled(true);
             ui->graphicsView->UpdateGraphicsItems(currentTileset, BGptr, L0ptr);
-            ui->ComboBox_LayerPriority->setCurrentIndex(0);
         }
     }
     else // Disable L0
     {
+        ui->spinBox_Layer0Width->setEnabled(false);
+        ui->spinBox_Layer0Height->setEnabled(false);
+        ui->ComboBox_Layer0Picker->setEnabled(false);
+        ui->graphicsView->UpdateGraphicsItems(currentTileset, BGptr, 0);
         ui->CheckBox_Layer0Alpha->setChecked(false);
         ui->CheckBox_Layer0Alpha->setEnabled(false);
     }

--- a/FileIOUtils.cpp
+++ b/FileIOUtils.cpp
@@ -377,7 +377,12 @@ bool FileIOUtils::ImportTile8x8GfxData(QWidget *parent, QVector<QRgb> ref_palett
             // Get the index of the color in the current palette
             QRgb findColor = tmppalette[i];
             auto paletteFound = std::find_if(ref_palette.begin(), ref_palette.end(),
-                [findColor](const QRgb& c) {return c == findColor;});
+                [&findColor](const QRgb& c)
+            {
+                QColor ca(c);
+                QColor cb(findColor);
+                return (ca.red() >> 3 == cb.red() >> 3) && (ca.green() >> 3 == cb.green() >> 3) && (ca.blue() >> 3 == cb.blue() >> 3);
+            });
             colorIndex = std::distance(ref_palette.begin(), paletteFound);
 
             // Edge cases if color not found

--- a/WL4EditorWindow.cpp
+++ b/WL4EditorWindow.cpp
@@ -225,6 +225,7 @@ void WL4EditorWindow::LoadROMDataFromFile(QString qFilePath)
         QMessageBox::critical(nullptr, QString(tr("Load Error")), QString(errorMessage));
         return;
     }
+    dialogInitialPath = QFileInfo(qFilePath).dir().path();
 
     // Clean-up
     if (CurrentLevel)
@@ -1535,7 +1536,8 @@ bool WL4EditorWindow::SaveCurrentFileAs()
         if (ROMUtils::SaveLevel(qFilePath))
         {
             // If successful in saving the file, set the window title to reflect the new file
-            ROMUtils::ROMFilePath = dialogInitialPath = qFilePath;
+            ROMUtils::ROMFilePath = qFilePath;
+            dialogInitialPath = QFileInfo(qFilePath).dir().path();
             std::string filePath = qFilePath.toStdString();
             std::string fileName = filePath.substr(filePath.rfind('/') + 1);
             setWindowTitle(fileName.c_str());


### PR DESCRIPTION
Fix #355 
Fix #356 and now dialogInitialPath can be initialized correctly when opening a ROM
Fix #357 and no more layer priority reset when change layer 0 mapping type