### PR TITLE
several new QoL changes on Tileset editor

### DIFF
--- a/Dialog/TilesetEditDialog.cpp
+++ b/Dialog/TilesetEditDialog.cpp
@@ -951,8 +951,10 @@ void TilesetEditDialog::on_pushButton_ImportTile16Graphic_clicked()
             }
 
             // ask user how many Tile16 per row, then update Tile16s' data to the Tile16 set
-            // TODO: intput TIle16_per_row
-            int Tile16_per_row = 1;
+            int Tile16_per_row = QInputDialog::getInt(parentPtr,
+                                                      tr("WL4Editor"),
+                                                      tr("Input the Tile16 number per row in your source file"),
+                                                      1, 1, 8);
             int Tile16_per_col = newtile16num / Tile16_per_row;
             if (Tile16_per_row * Tile16_per_col != newtile16num)
             {

--- a/Dialog/TilesetEditDialog.cpp
+++ b/Dialog/TilesetEditDialog.cpp
@@ -151,30 +151,30 @@ void TilesetEditDialog::DeleteFGTile8x8(int tile8x8id)
 /// </param>
 void TilesetEditDialog::SetTile16PaletteId(int tile16ID)
 {
-    UpdateATile8x8ForSelectedTile16InTilesetData(tile16ID,
-                                                 tilesetEditParams->newTileset->GetMap16arrayPtr()[tile16ID]->GetTile8X8(0)->GetIndex(),
-                                                 0,
-                                                 ui->spinBox_paletteBrushValue->value(),
-                                                 tilesetEditParams->newTileset->GetMap16arrayPtr()[tile16ID]->GetTile8X8(0)->GetFlipX(),
-                                                 tilesetEditParams->newTileset->GetMap16arrayPtr()[tile16ID]->GetTile8X8(0)->GetFlipY());
-    UpdateATile8x8ForSelectedTile16InTilesetData(tile16ID,
-                                                 tilesetEditParams->newTileset->GetMap16arrayPtr()[tile16ID]->GetTile8X8(1)->GetIndex(),
-                                                 1,
-                                                 ui->spinBox_paletteBrushValue->value(),
-                                                 tilesetEditParams->newTileset->GetMap16arrayPtr()[tile16ID]->GetTile8X8(1)->GetFlipX(),
-                                                 tilesetEditParams->newTileset->GetMap16arrayPtr()[tile16ID]->GetTile8X8(1)->GetFlipY());
-    UpdateATile8x8ForSelectedTile16InTilesetData(tile16ID,
-                                                 tilesetEditParams->newTileset->GetMap16arrayPtr()[tile16ID]->GetTile8X8(2)->GetIndex(),
-                                                 2,
-                                                 ui->spinBox_paletteBrushValue->value(),
-                                                 tilesetEditParams->newTileset->GetMap16arrayPtr()[tile16ID]->GetTile8X8(2)->GetFlipX(),
-                                                 tilesetEditParams->newTileset->GetMap16arrayPtr()[tile16ID]->GetTile8X8(2)->GetFlipY());
-    UpdateATile8x8ForSelectedTile16InTilesetData(tile16ID,
-                                                 tilesetEditParams->newTileset->GetMap16arrayPtr()[tile16ID]->GetTile8X8(3)->GetIndex(),
-                                                 3,
-                                                 ui->spinBox_paletteBrushValue->value(),
-                                                 tilesetEditParams->newTileset->GetMap16arrayPtr()[tile16ID]->GetTile8X8(3)->GetFlipX(),
-                                                 tilesetEditParams->newTileset->GetMap16arrayPtr()[tile16ID]->GetTile8X8(3)->GetFlipY());
+    auto tile16 = tilesetEditParams->newTileset->GetMap16arrayPtr()[tile16ID];
+    for (int i = 0; i < 4; i++)
+    {
+        UpdateATile8x8ForSelectedTile16InTilesetData(tile16ID,
+                                                     tile16->GetTile8X8(i)->GetIndex(),
+                                                     i,
+                                                     ui->spinBox_paletteBrushValue->value(),
+                                                     tile16->GetTile8X8(i)->GetFlipX(),
+                                                     tile16->GetTile8X8(i)->GetFlipY());
+    }
+}
+
+/// <summary>
+/// Clear the current Tile16 data, reset it to blank tile16
+/// </summary>
+/// <param name="tile16ID">
+/// Tile16's Id which are going to be set.
+/// </param>
+void TilesetEditDialog::ClearTile16Data(int tile16ID)
+{
+    for (int i = 0; i < 4; i++)
+    {
+        UpdateATile8x8ForSelectedTile16InTilesetData(tile16ID, 0x40, i, 0, false, false);
+    }
 }
 
 void TilesetEditDialog::on_spinBox_valueChanged(int arg1)

--- a/Dialog/TilesetEditDialog.cpp
+++ b/Dialog/TilesetEditDialog.cpp
@@ -601,7 +601,7 @@ void TilesetEditDialog::UpdateInfoTextBox()
 
     // Generate new Infos
     QString output;
-    output += tr("Unused Palette(s): (don't forget to clean up those trash Tile16 manually)\n");
+    output += tr("Unused Palette(s): (don't forget to clean up those unused Tile16 to free up the room for new palettes.)\n");
     QVector<int> unused_palettes = FindUnusedPalettes();
     for (auto palette_id: unused_palettes)
     {

--- a/Dialog/TilesetEditDialog.h
+++ b/Dialog/TilesetEditDialog.h
@@ -10,6 +10,7 @@
 #include <QColorDialog>
 #include <QTextStream>
 #include <QMessageBox>
+#include <QInputDialog>
 #include "LevelComponents/Room.h"
 #include "RoomPreviewGraphicsView.h"
 

--- a/Dialog/TilesetEditDialog.h
+++ b/Dialog/TilesetEditDialog.h
@@ -89,6 +89,7 @@ private slots:
     void on_pushButton_ExportPalette_clicked();
     void on_pushButton_ImportPalette_clicked();
     void on_pushButton_ImportTile16Graphic_clicked();
+    void on_pushButton_CleanUpDuplicatedTile8x8_clicked();
 
 private:
     Ui::TilesetEditDialog *ui;

--- a/Dialog/TilesetEditDialog.h
+++ b/Dialog/TilesetEditDialog.h
@@ -83,10 +83,9 @@ private slots:
     void on_pushButton_ExportTile8x8Map_clicked();
     void on_pushButton_ExportTile16Map_clicked();
     void on_pushButton_ImportTile8x8Graphic_clicked();
-    void on_pushButton_ExportTile16sCombinationData_clicked();
-    void on_pushButton_ImportTile16sCombinationData_clicked();
     void on_pushButton_ExportPalette_clicked();
     void on_pushButton_ImportPalette_clicked();
+    void on_pushButton_ImportTile16Graphic_clicked();
 
 private:
     Ui::TilesetEditDialog *ui;

--- a/Dialog/TilesetEditDialog.h
+++ b/Dialog/TilesetEditDialog.h
@@ -113,6 +113,9 @@ private:
     int SelectedPaletteId = 0;
     int paletteBrushVal = -1;
 
+    // helper functions
+    QVector<int> FindUnusedPalettes();
+
     // Setters for Selected Tile16
     void TLTile8x8Reset();
     void TRTile8x8Reset();
@@ -126,6 +129,7 @@ private:
     void ReRenderTile8x8Map(int paletteId);
     void UpdateATile8x8ForSelectedTile16InTilesetData(int tile16Id, int newTile8x8_Id, int position, int new_paletteIndex, bool xflip, bool yflip);
     void OverwriteATile8x8InTile8x8MapAndUpdateTile16Map(int posId, unsigned char *tiledata);
+    void UpdateInfoTextBox();
 };
 
 #endif // TILESETEDITDIALOG_H

--- a/Dialog/TilesetEditDialog.h
+++ b/Dialog/TilesetEditDialog.h
@@ -52,9 +52,11 @@ public:
     void DeleteFGTile8x8(int tile8x8id);
     int PaletteBrushValue() {return paletteBrushVal; }
     void SetTile16PaletteId(int tile16ID);
+    void ClearTile16Data(int tile16ID);
 
     int GetSelectedTile8x8() { return SelectedTile8x8; }
     int GetFGTile8x8Num() { return tilesetEditParams->newTileset->GetfgGFXlen() / 32; }
+    int GetSelectedTile16() { return SelectedTile16; }
 
     ~TilesetEditDialog();
 

--- a/Dialog/TilesetEditDialog.ui
+++ b/Dialog/TilesetEditDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1282</width>
-    <height>739</height>
+    <height>741</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -610,6 +610,13 @@
        </item>
        <item>
         <widget class="QTextEdit" name="textEdit_Infos"/>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButton_CleanUpDuplicatedTile8x8">
+         <property name="text">
+          <string>Clean up duplicated Tile8x8</string>
+         </property>
+        </widget>
        </item>
        <item>
         <spacer name="verticalSpacer_2">

--- a/Dialog/TilesetEditDialog.ui
+++ b/Dialog/TilesetEditDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1282</width>
-    <height>706</height>
+    <height>739</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -272,7 +272,7 @@
          <item>
           <widget class="QPushButton" name="pushButton_ImportTile8x8Graphic">
            <property name="text">
-            <string>Import and overwrite</string>
+            <string>Import and Overwrite</string>
            </property>
           </widget>
          </item>
@@ -301,23 +301,9 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QLabel" name="label_Tile16Combination">
+          <widget class="QPushButton" name="pushButton_ImportTile16Graphic">
            <property name="text">
-            <string>combination data:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="pushButton_ExportTile16sCombinationData">
-           <property name="text">
-            <string>Export</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="pushButton_ImportTile16sCombinationData">
-           <property name="text">
-            <string>Import</string>
+            <string>Import and Insert</string>
            </property>
           </widget>
          </item>

--- a/Dialog/TilesetEditDialog.ui
+++ b/Dialog/TilesetEditDialog.ui
@@ -52,11 +52,25 @@
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="label_palette">
-         <property name="text">
-          <string>Palette:</string>
+        <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <property name="topMargin">
+          <number>0</number>
          </property>
-        </widget>
+         <item>
+          <widget class="QLabel" name="label_palette">
+           <property name="text">
+            <string>Palette:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_Tile8x8SetPaletteId">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="QSlider" name="horizontalSlider">
@@ -303,7 +317,7 @@
          <item>
           <widget class="QPushButton" name="pushButton_ImportTile16Graphic">
            <property name="text">
-            <string>Import and Insert</string>
+            <string>Import and Overwrite</string>
            </property>
           </widget>
          </item>
@@ -593,6 +607,9 @@
           </widget>
          </item>
         </layout>
+       </item>
+       <item>
+        <widget class="QTextEdit" name="textEdit_Infos"/>
        </item>
        <item>
         <spacer name="verticalSpacer_2">

--- a/Dialog/TilesetEditor_Tile16MapGraphicView.cpp
+++ b/Dialog/TilesetEditor_Tile16MapGraphicView.cpp
@@ -34,3 +34,18 @@ void TilesetEditor_Tile16MapGraphicView::mouseReleaseEvent(QMouseEvent *event)
     }
     Inmouseslotfunction = false;
 }
+
+void TilesetEditor_Tile16MapGraphicView::keyPressEvent(QKeyEvent *event)
+{
+    switch (event->key())
+    {
+    // Clear the selected Tile16 if BSP or DEL is pressed
+    case Qt::Key_Backspace:
+    case Qt::Key_Delete:
+    {
+        int Tile16Id = TilesetEditor->GetSelectedTile16();
+        TilesetEditor->ClearTile16Data(Tile16Id);
+        TilesetEditor->SetSelectedTile16(Tile16Id - 1, false);
+    }
+    }
+}

--- a/Dialog/TilesetEditor_Tile16MapGraphicView.h
+++ b/Dialog/TilesetEditor_Tile16MapGraphicView.h
@@ -15,6 +15,7 @@ public:
     TilesetEditor_Tile16MapGraphicView(QWidget *param) : QGraphicsView(param) {}
     void mousePressEvent(QMouseEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);
+    void keyPressEvent(QKeyEvent *event);
     void SetCurrentTilesetEditor(TilesetEditDialog *currentEditor) { TilesetEditor = currentEditor; }
 
 private:

--- a/FileIOUtils.cpp
+++ b/FileIOUtils.cpp
@@ -293,7 +293,9 @@ bool FileIOUtils::ImportPalette(QWidget *parent, std::function<void (int, int, Q
 /// <returns>
 /// True if the save was successful.
 /// </returns>
-bool FileIOUtils::ImportTile8x8GfxData(QWidget *parent, QVector<QRgb> ref_palette, std::function<void (QByteArray&, QWidget *)> TilesReplaceCallback)
+bool FileIOUtils::ImportTile8x8GfxData(QWidget *parent,
+                                       QVector<QRgb> ref_palette,
+                                       std::function<void (QByteArray&, QWidget *)> TilesReplaceCallback)
 {
     if (ref_palette.size() != 16)
     {

--- a/FileIOUtils.h
+++ b/FileIOUtils.h
@@ -13,7 +13,9 @@ namespace FileIOUtils
     QString LoadROMFile(QString filePath);
     bool ExportPalette(QWidget *parent, QVector<QRgb> palette);
     bool ImportPalette(QWidget *parent, std::function<void(int, int, QRgb)> SetColorFunction, int selectedPalId);
-    bool ImportTile8x8GfxData(QWidget *parent, QVector<QRgb> ref_palette, std::function<void (QByteArray&, QWidget *)> TilesReplaceCallback);
+    bool ImportTile8x8GfxData(QWidget *parent,
+                              QVector<QRgb> ref_palette,
+                              std::function<void (QByteArray&, QWidget *)> TilesReplaceCallback);
     QImage RenderBGColor(QImage image, QWidget *parent);
 } // namespace FileIOUtils
 

--- a/ROMUtils.cpp
+++ b/ROMUtils.cpp
@@ -147,6 +147,45 @@ namespace ROMUtils
     }
 
     /// <summary>
+    /// Get an 32 bytes uchar array of Tile8x8 graphic data, then X flip the data of its graphic.
+    /// </summary>
+    /// <param name="source">
+    /// The pointer to read uchar array Tile8x8 data.
+    /// </param>
+    /// <param name="destination">
+    /// The pointer to save changed Tile8x8 data to.
+    /// </param>
+    void Tile8x8DataXFlip(unsigned char *source, unsigned char *destination)
+    {
+        for (int col = 0; col < 8; col++)
+        {
+            for (int row = 0; row < 4; row++)
+            {
+                unsigned char curByte = source[col * 4 + row];
+                curByte = ((curByte & 0xF) << 4) | ((curByte & 0xF0) >> 4);
+                destination[col * 4 + (3 - row)] = curByte;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Get an 32 bytes uchar array of Tile8x8 graphic data, then Y flip the data of its graphic.
+    /// </summary>
+    /// <param name="source">
+    /// The pointer to read uchar array Tile8x8 data.
+    /// </param>
+    /// <param name="destination">
+    /// The pointer to save changed Tile8x8 data to.
+    /// </param>
+    void Tile8x8DataYFlip(unsigned char *source, unsigned char *destination)
+    {
+        for (int col = 0; col < 8; col++)
+        {
+            memcpy(&destination[col * 4], &source[(7 - col) * 4], 4 * sizeof(unsigned char));
+        }
+    }
+
+    /// <summary>
     /// Reverse the endianness of an integer.
     /// </summary>
     /// <param name="n">

--- a/ROMUtils.h
+++ b/ROMUtils.h
@@ -96,6 +96,8 @@ namespace ROMUtils
     void CleanUpTmpCurrentFileMetaData();
     unsigned int IntFromData(int address);
     unsigned int PointerFromData(int address);
+    void Tile8x8DataXFlip(unsigned char *source, unsigned char *destination);
+    void Tile8x8DataYFlip(unsigned char *source, unsigned char *destination);
     unsigned int PackScreen(unsigned short *screenCharData, unsigned short *&outputCompressedData, bool skipzeros = true);
     unsigned short *UnPackScreen(uint32_t address);
     unsigned char *LayerRLEDecompress(int address, size_t outputSize);


### PR DESCRIPTION
Add info textbox in Tileset Editor to show unused palettes
Now you can import Tile16 with the same way you import Tile8x8
more update on the same branch: Press BSP or DEL to delete selected Tile16 Tileset Editor
Support cleanup duplicated Tile8x8 from the Tile8x8 set and Tile16 set in Tileset Editor