### PR TITLE
clean up patch info when delete patch(es)

### DIFF
--- a/Dialog/PatchManagerDialog.cpp
+++ b/Dialog/PatchManagerDialog.cpp
@@ -270,6 +270,7 @@ void PatchManagerDialog::on_removePatchButton_clicked()
     {
         ui->savePatchButton->setEnabled(initialEntries);
     }
+    ui->textEdit_PatchDescription->setText(tr(""));
 }
 
 /// <summary>


### PR DESCRIPTION
a UI logic fix to a previous PR