### PR TITLE
Scripting features tweak 20230104

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           architecture: 'x64'  
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3
         with:
           version: 5.14.1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          version: 5.14.1
+          version: 5.15.2
 
       - name: Setup MSVC environment
         if: startsWith(matrix.os, 'windows')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,15 +17,15 @@ jobs:
         os: [windows-latest, macOS-latest, ubuntu-latest]
     steps:
       - name: Download Submodules
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
           
-      - name: Install Python 3.7 version
-        uses: actions/setup-python@v1
+      - name: Install Python 3.X version
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
-          architecture: 'x64'  
+          python-version: '3.10'
+          architecture: 'x64'
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/DockWidget/OutputDockWidget.cpp
+++ b/DockWidget/OutputDockWidget.cpp
@@ -94,3 +94,12 @@ void OutputDockWidget::on_pushButton_Execute_clicked()
         ui->lineEdit_JsCode->clear();
     }
 }
+
+/// <summary>
+/// slot function when clicking pushButton_Abort.
+/// </summary>
+void OutputDockWidget::on_pushButton_Abort_clicked()
+{
+    jsEngine.setInterrupted(true);
+}
+

--- a/DockWidget/OutputDockWidget.cpp
+++ b/DockWidget/OutputDockWidget.cpp
@@ -23,7 +23,7 @@ OutputDockWidget::OutputDockWidget(QWidget *parent) :
         interface = new ScriptInterface();
     }
     QJSValue funcInterface = jsEngine.newQObject(interface);
-    jsEngine.globalObject().setProperty("interface", funcInterface);
+    jsEngine.globalObject().setProperty("WL4EditorInterface", funcInterface);
 
     // Initialize tileUtils and use "TileUtils" to call its member functions
     if (!tileUtils)

--- a/DockWidget/OutputDockWidget.h
+++ b/DockWidget/OutputDockWidget.h
@@ -25,6 +25,7 @@ public:
 
 private slots:
     void on_pushButton_Execute_clicked();
+    void on_pushButton_Abort_clicked();
 
 private:
     Ui::OutputDockWidget *ui;

--- a/DockWidget/OutputDockWidget.ui
+++ b/DockWidget/OutputDockWidget.ui
@@ -10,9 +10,6 @@
     <height>200</height>
    </rect>
   </property>
-  <property name="features">
-   <set>QDockWidget::AllDockWidgetFeatures</set>
-  </property>
   <property name="allowedAreas">
    <set>Qt::BottomDockWidgetArea</set>
   </property>
@@ -40,6 +37,13 @@
        <widget class="QPushButton" name="pushButton_Execute">
         <property name="text">
          <string>Execute</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pushButton_Abort">
+        <property name="text">
+         <string>Abort</string>
         </property>
        </widget>
       </item>

--- a/PCG/Graphics/TileUtils.cpp
+++ b/PCG/Graphics/TileUtils.cpp
@@ -19,7 +19,7 @@ int PCG::GFXUtils::TileUtils::GetFitness_CurTilesetJoinTile16_UL(unsigned int up
     LevelComponents::Tileset *tileset = ROMUtils::singletonTilesets[tileset_id];
     auto tile16s = tileset->GetMap16arrayPtr();
     int tmp_result = GetFitnessJoinTile16_UL(tile16s[upper_tile16_id], tile16s[lower_tile16_id]);
-    if (tmp_result == 0xFF * 16 * 3 && (upper_tile16_id == 0 || lower_tile16_id == 0))
+    if (tmp_result == max_Tile16_border_pixels_color_channel_diff_value && (upper_tile16_id == 0 || lower_tile16_id == 0))
         return 0;
     return tmp_result;
 }
@@ -30,7 +30,7 @@ int PCG::GFXUtils::TileUtils::GetFitness_CurTilesetJoinTile16_LR(unsigned int le
     LevelComponents::Tileset *tileset = ROMUtils::singletonTilesets[tileset_id];
     auto tile16s = tileset->GetMap16arrayPtr();
     int tmp_result = GetFitnessJoinTile16_LR(tile16s[left_tile16_id], tile16s[right_tile16_id]);
-    if (tmp_result == 0xFF * 16 * 3 && (left_tile16_id == 0 || right_tile16_id == 0))
+    if (tmp_result == max_Tile16_border_pixels_color_channel_diff_value && (left_tile16_id == 0 || right_tile16_id == 0))
         return 0;
     return tmp_result;
 }
@@ -86,7 +86,7 @@ int PCG::GFXUtils::TileUtils::GetFitnessJoinTile16_UL(LevelComponents::TileMap16
             u_black_pixel += 1;
         }
         if (l_black_pixel > 8 || u_black_pixel > 8)
-            return 0xFF * 16 * 3;
+            return max_Tile16_border_pixels_color_channel_diff_value;
         delta_r[i] = border_u[i].red() - border_l[i].red();
         delta_g[i] = border_u[i].green() - border_l[i].green();
         delta_b[i] = border_u[i].blue() - border_l[i].blue();
@@ -132,7 +132,7 @@ int PCG::GFXUtils::TileUtils::GetFitnessJoinTile16_LR(LevelComponents::TileMap16
             r_black_pixel += 1;
         }
         if (l_black_pixel > 8 || r_black_pixel > 8)
-            return 0xFF * 16 * 3;
+            return max_Tile16_border_pixels_color_channel_diff_value;
         delta_r[i] = border_l[i].red() - border_r[i].red();
         delta_g[i] = border_l[i].green() - border_r[i].green();
         delta_b[i] = border_l[i].blue() - border_r[i].blue();

--- a/PCG/Graphics/TileUtils.cpp
+++ b/PCG/Graphics/TileUtils.cpp
@@ -18,7 +18,10 @@ int PCG::GFXUtils::TileUtils::GetFitness_CurTilesetJoinTile16_UL(unsigned int up
     int tileset_id = singleton->GetCurrentRoom()->GetTilesetID();
     LevelComponents::Tileset *tileset = ROMUtils::singletonTilesets[tileset_id];
     auto tile16s = tileset->GetMap16arrayPtr();
-    return GetFitnessJoinTile16_UL(tile16s[upper_tile16_id], tile16s[lower_tile16_id]);
+    int tmp_result = GetFitnessJoinTile16_UL(tile16s[upper_tile16_id], tile16s[lower_tile16_id]);
+    if (tmp_result == 0xFF * 16 * 3 && (upper_tile16_id == 0 || lower_tile16_id == 0))
+        return 0;
+    return tmp_result;
 }
 
 int PCG::GFXUtils::TileUtils::GetFitness_CurTilesetJoinTile16_LR(unsigned int left_tile16_id, unsigned int right_tile16_id)
@@ -26,7 +29,10 @@ int PCG::GFXUtils::TileUtils::GetFitness_CurTilesetJoinTile16_LR(unsigned int le
     int tileset_id = singleton->GetCurrentRoom()->GetTilesetID();
     LevelComponents::Tileset *tileset = ROMUtils::singletonTilesets[tileset_id];
     auto tile16s = tileset->GetMap16arrayPtr();
-    return GetFitnessJoinTile16_LR(tile16s[left_tile16_id], tile16s[right_tile16_id]);
+    int tmp_result = GetFitnessJoinTile16_LR(tile16s[left_tile16_id], tile16s[right_tile16_id]);
+    if (tmp_result == 0xFF * 16 * 3 && (left_tile16_id == 0 || right_tile16_id == 0))
+        return 0;
+    return tmp_result;
 }
 
 bool PCG::GFXUtils::TileUtils::IsBlankTile_CurTilesetTile16(unsigned int tile16_id)
@@ -63,33 +69,30 @@ int PCG::GFXUtils::TileUtils::GetFitnessJoinTile16_UL(LevelComponents::TileMap16
     // get the color difference between the bottom row of the upper tile16 and the top row of the lower tile16 per pixel
     QColor border_u[16], border_l[16];
     int delta_r[16], delta_g[16], delta_b[16];
+    double diff_r = 0.0, diff_b = 0.0, diff_g = 0.0;
     QImage image = pixmap.toImage();
+    char l_black_pixel = 0;
+    char u_black_pixel = 0;
     for (int i = 0; i < 16; i++)
     {
         border_u[i] = image.pixel(i, 15);
         border_l[i] = image.pixel(i, 16);
+        if (border_l[i].red() < 8 && border_l[i].green() < 8 && border_l[i].blue() < 8)
+        {
+            l_black_pixel += 1;
+        }
+        if (border_u[i].red() < 8 && border_u[i].green() < 8 && border_u[i].blue() < 8)
+        {
+            u_black_pixel += 1;
+        }
+        if (l_black_pixel > 8 || u_black_pixel > 8)
+            return 0xFF * 16 * 3;
         delta_r[i] = border_u[i].red() - border_l[i].red();
         delta_g[i] = border_u[i].green() - border_l[i].green();
         delta_b[i] = border_u[i].blue() - border_l[i].blue();
-    }
-
-    // the check if the 16 differences pixel pair looks similar in changes from the upper tile16 to lower tile16
-    double ave_r = 0.0, ave_b = 0.0, ave_g = 0.0;
-    for (int i = 0; i < 16; i++)
-    {
-        ave_r += (double)delta_r[i];
-        ave_g += (double)delta_g[i];
-        ave_b += (double)delta_b[i];
-    }
-    ave_r = ave_r / 16.0;
-    ave_g = ave_g / 16.0;
-    ave_b = ave_b / 16.0;
-    double diff_r = 0.0, diff_b = 0.0, diff_g = 0.0;
-    for (int i = 0; i < 16; i++)
-    {
-        diff_r += (double)delta_r[i] - ave_r;
-        diff_g += (double)delta_g[i] - ave_g;
-        diff_b += (double)delta_b[i] - ave_b;
+        diff_r += (double)delta_r[i];
+        diff_g += (double)delta_g[i];
+        diff_b += (double)delta_b[i];
     }
     return diff_r + diff_b + diff_g;
 }
@@ -112,33 +115,30 @@ int PCG::GFXUtils::TileUtils::GetFitnessJoinTile16_LR(LevelComponents::TileMap16
     // get the color difference between the bottom row of the upper tile16 and the top row of the lower tile16 per pixel
     QColor border_l[16], border_r[16];
     int delta_r[16], delta_g[16], delta_b[16];
+    double diff_r = 0.0, diff_b = 0.0, diff_g = 0.0;
     QImage image = pixmap.toImage();
+    char l_black_pixel = 0;
+    char r_black_pixel = 0;
     for (int i = 0; i < 16; i++)
     {
         border_l[i] = image.pixel(15, i);
         border_r[i] = image.pixel(16, i);
+        if (border_l[i].red() < 8 && border_l[i].green() < 8 && border_l[i].blue() < 8)
+        {
+            l_black_pixel += 1;
+        }
+        if (border_r[i].red() < 8 && border_r[i].green() < 8 && border_r[i].blue() < 8)
+        {
+            r_black_pixel += 1;
+        }
+        if (l_black_pixel > 8 || r_black_pixel > 8)
+            return 0xFF * 16 * 3;
         delta_r[i] = border_l[i].red() - border_r[i].red();
         delta_g[i] = border_l[i].green() - border_r[i].green();
         delta_b[i] = border_l[i].blue() - border_r[i].blue();
-    }
-
-    // the check if the 16 differences pixel pair looks similar in changes from the upper tile16 to lower tile16
-    double ave_r = 0.0, ave_b = 0.0, ave_g = 0.0;
-    for (int i = 0; i < 16; i++)
-    {
-        ave_r += (double)delta_r[i];
-        ave_g += (double)delta_g[i];
-        ave_b += (double)delta_b[i];
-    }
-    ave_r = ave_r / 16.0;
-    ave_g = ave_g / 16.0;
-    ave_b = ave_b / 16.0;
-    double diff_r = 0.0, diff_b = 0.0, diff_g = 0.0;
-    for (int i = 0; i < 16; i++)
-    {
-        diff_r += (double)delta_r[i] - ave_r;
-        diff_g += (double)delta_g[i] - ave_g;
-        diff_b += (double)delta_b[i] - ave_b;
+        diff_r += (double)delta_r[i];
+        diff_g += (double)delta_g[i];
+        diff_b += (double)delta_b[i];
     }
     return diff_r + diff_b + diff_g;
 }

--- a/PCG/Graphics/TileUtils.h
+++ b/PCG/Graphics/TileUtils.h
@@ -24,6 +24,10 @@ namespace PCG
             int GetFitnessJoinTile16_LR(LevelComponents::TileMap16 *Left_tile16, LevelComponents::TileMap16 *Right_tile16);
 
         signals:
+            // nothings here
+
+        private:
+            static const int max_Tile16_border_pixels_color_channel_diff_value = 0xFF * 16 * 3;
 
         };
     }

--- a/ScriptInterface.cpp
+++ b/ScriptInterface.cpp
@@ -8,6 +8,8 @@
 extern WL4EditorWindow *singleton;
 #endif
 
+#include <QApplication>
+
 // ---------------------------Helper functions--------------------------------------
 unsigned short *QStringToU16(QString input)
 {
@@ -562,6 +564,11 @@ QString ScriptInterface::prompt(QString message, QString defaultInput)
 void ScriptInterface::UpdateRoomGFXFull()
 {
     singleton->RenderScreenFull();
+}
+
+void ScriptInterface::DoEvents()
+{
+    QApplication::processEvents();
 }
 
 void ScriptInterface::WriteTxtFile(QString filepath, QString test)

--- a/ScriptInterface.cpp
+++ b/ScriptInterface.cpp
@@ -451,6 +451,22 @@ QString ScriptInterface::GetEntityListData(int entitylistid)
     return result;
 }
 
+QString ScriptInterface::GetCurRoomAllDoorsRangeData()
+{
+    auto doorlist = singleton->GetCurrentRoom()->GetDoors();
+    QString result = "";
+    for (auto &door: doorlist)
+    {
+        int x1 = door->GetX1();
+        int x2 = door->GetX2();
+        int y1 = door->GetY1();
+        int y2 = door->GetY2();
+        result += QString::number(x1, 10) + "," + QString::number(x2, 10) + "," + QString::number(y1, 10) + "," + QString::number(y2, 10) + ";";
+    }
+    result.chop(1); // get rid of the last ";"
+    return result;
+}
+
 void ScriptInterface::SetEntityListData(QString entitylistdata, int entitylistid)
 {
     QStringList EntitylistStrData = entitylistdata.split(QChar(' '), Qt::SkipEmptyParts);

--- a/ScriptInterface.h
+++ b/ScriptInterface.h
@@ -51,6 +51,7 @@ public:
 
     // UI
     Q_INVOKABLE void UpdateRoomGFXFull();
+    Q_INVOKABLE void DoEvents();
 
     // File operations
     Q_INVOKABLE void WriteTxtFile(QString filePath = QString(""), QString test = "");

--- a/ScriptInterface.h
+++ b/ScriptInterface.h
@@ -24,6 +24,7 @@ public:
     Q_INVOKABLE int GetCurTilesetTile16EventId(unsigned short tile16Id);
     Q_INVOKABLE int GetCurTilesetTile16TerrainType(unsigned short tile16Id);
     Q_INVOKABLE QString GetEntityListData(int entitylistid = -1);
+    Q_INVOKABLE QString GetCurRoomAllDoorsRangeData();
 
     // Test
     Q_INVOKABLE void _UnpackScreen(int address);

--- a/SettingsUtils.cpp
+++ b/SettingsUtils.cpp
@@ -136,7 +136,7 @@ namespace SettingsUtils
         if (list.contains(key) && jsonObj[key].isBool())
         {
             // accept and apply the correct key - value pair
-            singleton->GetOutputWidgetPtr()->PrintString("project setting file loaded correctly.");
+            singleton->GetOutputWidgetPtr()->PrintString("project setting file loaded correctly.\n");
         }
         // modify the key and value to the correct default contents, and write the value we read to the new json, so it is always clean
         json.insert(key, true);


### PR DESCRIPTION
- modify logics of 2 script API functions GetFitnessJoinTile16_XX(), they can at least work this time, but only work like some helper functions. you cannot use it to directly decide if 2 Tile16 can be bind together since i am unable to implement edge cases for things like id 0 Tile16 and a Tile16 stand for solid block with black border
- change the API container object name from "interface" to "WL4EditorInterface" due to js unimplemented but reserved keywords will result in Error when executing the js script
- Add API: DoEvents(), which does something similar to the DoEvents() in VB, but it can only be used to re-render the Room atm. the WL4Editor itself will keep hanging on the fly
- Add the "Abort" button for the js script output window
- Add another API: QString ScriptInterface::GetCurRoomAllDoorsRangeData()