### PR TITLE
Room Config dialog data operation logic rewrite

### DIFF
--- a/Dialog/RoomConfigDialog.cpp
+++ b/Dialog/RoomConfigDialog.cpp
@@ -26,10 +26,7 @@ static unsigned short *ChangeLayerDimensions(int newWidth, int newHeight, int ol
     unsigned short defaultValue = 0x0000;
 
     // init
-    for (int i = 0; i < newWidth * newHeight; ++i)
-    {
-        tmpLayerData[i] = defaultValue;
-    }
+    memset(tmpLayerData, defaultValue, 2 * newWidth * newHeight);
 
     // copy old data
     if (oldWidth > 0 && oldHeight > 0)

--- a/Dialog/RoomConfigDialog.cpp
+++ b/Dialog/RoomConfigDialog.cpp
@@ -16,6 +16,35 @@ constexpr unsigned int RoomConfigDialog::VanillaTilesetBGTilesDataAddr[0x5C];
 static QStringList TilesetNamesSet, LayerPrioritySet, AlphaBlendAttrsSet;
 static std::vector<int> BGLayerdataPtrs;
 
+// helper function
+static unsigned short *ChangeLayerDimensions(int newWidth, int newHeight, int oldWidth, int oldHeight, unsigned short *oldData)
+{
+    if ((newWidth < 1 || newHeight < 1) || (oldData == nullptr)) return nullptr;
+
+    unsigned short *tmpLayerData = new unsigned short[newWidth * newHeight];
+    int boundX = qMin(oldWidth, newWidth), boundY = qMin(oldHeight, newHeight);
+    unsigned short defaultValue = 0x0000;
+
+    // init
+    for (int i = 0; i < newWidth * newHeight; ++i)
+    {
+        tmpLayerData[i] = defaultValue;
+    }
+
+    // copy old data
+    if (oldWidth > 0 && oldHeight > 0)
+    {
+        for (int i = 0; i < boundY; ++i)
+        {
+            for (int j = 0; j < boundX; ++j)
+            {
+                tmpLayerData[i * newWidth + j] = oldData[i * oldWidth + j];
+            }
+        }
+    }
+    return tmpLayerData;
+}
+
 /// <summary>
 /// Construct the instance of the RoomConfigDialog.
 /// </summary>
@@ -109,42 +138,70 @@ RoomConfigDialog::~RoomConfigDialog() { delete ui; }
 /// <summary>
 /// Get the selected config parameters based on the UI selections.
 /// </summary>
+/// <param name="prevRoomParams">
+/// Use the prevRoomParams to config layerdata in the new configParams.
+/// </param>
 /// <returns>
 /// A RoomConfigParams struct containing the selected parameters from the dialog.
 /// </returns>
-DialogParams::RoomConfigParams RoomConfigDialog::GetConfigParams()
+DialogParams::RoomConfigParams *RoomConfigDialog::GetConfigParams(DialogParams::RoomConfigParams *prevRoomParams)
 {
-    DialogParams::RoomConfigParams configParams;
+    DialogParams::RoomConfigParams *configParams = new DialogParams::RoomConfigParams();
 
     // Get all the Room Configuration data
-    configParams.CurrentTilesetIndex = ui->ComboBox_TilesetID->currentIndex();
-    configParams.Layer0Alpha = ui->CheckBox_Layer0Alpha->isChecked();
-    configParams.Layer0MappingTypeParam = ui->spinBox_Layer0MappingType->value();
-    if((configParams.Layer0MappingTypeParam & 0x10) == LevelComponents::LayerMap16)
+    configParams->CurrentTilesetIndex = ui->ComboBox_TilesetID->currentIndex();
+    configParams->Layer0Alpha = ui->CheckBox_Layer0Alpha->isChecked();
+    configParams->Layer0MappingTypeParam = ui->spinBox_Layer0MappingType->value();
+    if((configParams->Layer0MappingTypeParam & 0x30) == LevelComponents::LayerMap16)
     {
-        configParams.Layer0Width = ui->spinBox_Layer0Width->value();
-        configParams.Layer0Height = ui->spinBox_Layer0Height->value();
+        configParams->Layer0Width = ui->spinBox_Layer0Width->value();
+        configParams->Layer0Height = ui->spinBox_Layer0Height->value();
+        configParams->Layer0DataPtr = 0;
     }
-    configParams.Layer0DataPtr = ui->ComboBox_Layer0Picker->currentText().toUInt(nullptr, 16);
-
-    configParams.Layer2MappingTypeParam = ui->spinBox_Layer2MappingType->value();
-    configParams.LayerPriorityAndAlphaAttr = ui->ComboBox_LayerPriority->currentIndex() + 4;
-    configParams.LayerPriorityAndAlphaAttr += (qMax(ui->ComboBox_AlphaBlendAttribute->currentIndex(), 0) << 2);
-    configParams.BackgroundLayerEnable = ui->CheckBox_BGLayerEnable->isChecked();
-    configParams.BGLayerScrollFlag = ui->spinBox_BGLayerScrollingFlag->value();
-    if (configParams.BackgroundLayerEnable)
+    else if ((configParams->Layer0MappingTypeParam & 0x30) == LevelComponents::LayerTile8x8)
     {
-        configParams.BackgroundLayerDataPtr = ui->ComboBox_BGLayerPicker->currentText().toUInt(nullptr, 16);
+        configParams->Layer0Width = configParams->Layer0Height = 0;
+        configParams->Layer0DataPtr = ui->ComboBox_Layer0Picker->currentText().toUInt(nullptr, 16);
     }
     else
     {
-        configParams.BackgroundLayerDataPtr = WL4Constants::BGLayerDefaultPtr;
+        configParams->Layer0DataPtr = configParams->Layer0Width = configParams->Layer0Height = 0;
     }
-    configParams.RoomHeight = ui->SpinBox_RoomHeight->value();
-    configParams.RoomWidth = ui->SpinBox_RoomWidth->value();
-    configParams.RasterType = ui->spinBox_RasterType->value();
-    configParams.Water = ui->spinBox_Water->value();
-    configParams.BGMVolume = ui->spinBox_BgmVolume->value();
+
+    configParams->Layer2MappingTypeParam = ui->spinBox_Layer2MappingType->value();
+    configParams->LayerPriorityAndAlphaAttr = ui->ComboBox_LayerPriority->currentIndex() + 4;
+    configParams->LayerPriorityAndAlphaAttr += (qMax(ui->ComboBox_AlphaBlendAttribute->currentIndex(), 0) << 2);
+    configParams->BackgroundLayerEnable = ui->CheckBox_BGLayerEnable->isChecked();
+    configParams->BGLayerScrollFlag = ui->spinBox_BGLayerScrollingFlag->value();
+    if (configParams->BackgroundLayerEnable)
+    {
+        configParams->BackgroundLayerDataPtr = ui->ComboBox_BGLayerPicker->currentText().toUInt(nullptr, 16);
+    }
+    else
+    {
+        configParams->BackgroundLayerDataPtr = WL4Constants::BGLayerDefaultPtr;
+    }
+    configParams->RoomHeight = ui->SpinBox_RoomHeight->value();
+    configParams->RoomWidth = ui->SpinBox_RoomWidth->value();
+    configParams->RasterType = ui->spinBox_RasterType->value();
+    configParams->Water = ui->spinBox_Water->value();
+    configParams->BGMVolume = ui->spinBox_BgmVolume->value();
+
+    // Reset Layers, iterate 0, 1, 2
+    if((configParams->Layer0MappingTypeParam & 0x30) == LevelComponents::LayerMap16) {
+        configParams->LayerData[0] = ChangeLayerDimensions(configParams->Layer0Width, configParams->Layer0Height,
+                                                          prevRoomParams->Layer0Width, prevRoomParams->Layer0Height, prevRoomParams->LayerData[0]);
+    } else {
+        configParams->LayerData[0] = nullptr;
+    }
+    configParams->LayerData[1] = ChangeLayerDimensions(configParams->RoomWidth, configParams->RoomHeight,
+                                                      prevRoomParams->RoomWidth, prevRoomParams->RoomHeight, prevRoomParams->LayerData[1]);
+    if((configParams->Layer2MappingTypeParam & 0x30) == LevelComponents::LayerMap16) {
+        configParams->LayerData[2] = ChangeLayerDimensions(configParams->RoomWidth, configParams->RoomHeight,
+                                                          prevRoomParams->RoomWidth, prevRoomParams->RoomHeight, prevRoomParams->LayerData[2]);
+    } else {
+        configParams->LayerData[2] = nullptr;
+    }
 
     return configParams;
 }

--- a/LevelComponents/Layer.cpp
+++ b/LevelComponents/Layer.cpp
@@ -285,69 +285,6 @@ namespace LevelComponents
     }
 
     /// <summary>
-    /// Use this function to take the place of one existing layer in a room.
-    /// </summary>
-    /// <param name="layerWidth">
-    /// New layer width.
-    /// </param>
-    /// <param name="layerHeight">
-    /// New layer height.
-    /// </param>
-    void Layer::CreateNewLayer_type0x10(int layerWidth, int layerHeight)
-    {
-        Width = layerWidth;
-        Height = layerHeight;
-        dirty = Enabled = true;
-        MappingType = LayerMap16;
-        if (LayerData)
-        {
-            delete[] LayerData;
-        }
-        LayerData = new unsigned short[layerWidth * layerHeight];
-        memset(LayerData, 0, 2 * layerWidth * layerHeight);
-    }
-
-    /// <summary>
-    /// Change the size of the Layer.
-    /// </summary>
-    /// <remarks>
-    /// This function will initialize new tiles to 0x40
-    /// </remarks>
-    /// <param name="newWidth">
-    /// New layer width.
-    /// </param>
-    /// <param name="newHeight">
-    /// New layer height.
-    /// </param>
-    void Layer::ChangeDimensions(int newWidth, int newHeight)
-    {
-        unsigned short *tmpLayerData = new unsigned short[newWidth * newHeight];
-        int boundX = qMin(Width, newWidth), boundY = qMin(Height, newHeight);
-        unsigned short defaultValue = 0x0000;
-
-        // init
-        for (int i = 0; i < newWidth * newHeight; ++i)
-        {
-            tmpLayerData[i] = defaultValue;
-        }
-
-        // copy old data
-        for (int i = 0; i < boundY; ++i)
-        {
-            for (int j = 0; j < boundX; ++j)
-            {
-                tmpLayerData[i * newWidth + j] = LayerData[i * Width + j];
-            }
-        }
-
-        Width = newWidth;
-        Height = newHeight;
-        delete LayerData;
-        LayerData = tmpLayerData;
-        dirty = true;
-    }
-
-    /// <summary>
     /// Create and returned compressed layer data (on the heap)
     /// </summary>
     /// <param name="dataSize">

--- a/LevelComponents/Layer.h
+++ b/LevelComponents/Layer.h
@@ -71,17 +71,11 @@ namespace LevelComponents
             LayerData = new unsigned short[Width * Height];
             if (data != nullptr)
             {
-                for (int i = 0; i < (Width * Height); i++)
-                {
-                    LayerData[i] = data[i];
-                }
+                memcpy(LayerData, data, 2 * Width * Height);
             }
             else
             {
-                for (int i = 0; i < (Width * Height); i++)
-                {
-                    LayerData[i] = 0x0000;
-                }
+                memset(LayerData, 0, 2 * Width * Height);
             }
         }
         bool IsDirty() { return dirty; }

--- a/LevelComponents/Layer.h
+++ b/LevelComponents/Layer.h
@@ -36,6 +36,13 @@ namespace LevelComponents
         int GetLayerHeight() { return Height; }
         enum LayerMappingType GetMappingType() { return MappingType; }
         unsigned short *GetLayerData() { return LayerData; }
+        unsigned short *CreateLayerDataCopy()
+        {
+            if (MappingType != LayerMap16) return nullptr;
+            unsigned short *datacopy = new unsigned short[Width * Height];
+            memcpy(datacopy, LayerData, 2 * Width * Height);
+            return datacopy;
+        }
         void SetLayerData(unsigned short *ptr) { LayerData = ptr; }
         void SetTileData(unsigned short id, unsigned char x, unsigned char y)
         {
@@ -54,8 +61,29 @@ namespace LevelComponents
         std::vector<Tile *> GetTiles() { return tiles; }
         bool IsEnabled() { return Enabled; }
         void SetDisabled();
-        void CreateNewLayer_type0x10(int layerWidth, int layerHeight);
-        void ChangeDimensions(int newWidth, int newHeight);
+        void SetWidthHeightData(int layerWidth, int layerHeight, unsigned short *data)
+        {
+            if (layerWidth < 1 || layerHeight < 1) return;
+            SetDisabled();
+            MappingType = LayerMap16;
+            Enabled = true;
+            Width = layerWidth; Height = layerHeight;
+            LayerData = new unsigned short[Width * Height];
+            if (data != nullptr)
+            {
+                for (int i = 0; i < (Width * Height); i++)
+                {
+                    LayerData[i] = data[i];
+                }
+            }
+            else
+            {
+                for (int i = 0; i < (Width * Height); i++)
+                {
+                    LayerData[i] = 0x0000;
+                }
+            }
+        }
         bool IsDirty() { return dirty; }
         void SetDirty(bool _dirty) { dirty = _dirty; }
         unsigned char *GetCompressedLayerData(unsigned int *dataSize);

--- a/LevelComponents/Room.h
+++ b/LevelComponents/Room.h
@@ -153,6 +153,7 @@ namespace LevelComponents
 
     public:
         // Object construction
+        Room(unsigned char _RoomID, unsigned int _LevelID, unsigned char _tilesetId, unsigned char _entitysetId);
         Room(int roomDataPtr, unsigned char _RoomID, unsigned int _LevelID);
         Room(Room *room);
         ~Room();

--- a/WL4Constants.cpp
+++ b/WL4Constants.cpp
@@ -1,6 +1,0 @@
-namespace WL4Constants
-{
-    const int LevelHeaderIndexTable = 0x6391C4;
-    const int RoomDataTable = 0x78F280;
-    const int DoorTable = 0x78F21C;
-} // namespace WL4Constants

--- a/WL4EditorWindow.cpp
+++ b/WL4EditorWindow.cpp
@@ -2256,6 +2256,7 @@ void WL4EditorWindow::on_actionNew_Room_triggered()
                                                     CurrentLevel->GetLevelID(),
                                                     GetCurrentRoom()->GetTilesetID(),
                                                     entitysetId));
+    LevelComponents::Room *newRoom = CurrentLevel->GetRooms()[newRoomId];
 
     // Add one Door to the new Room as well as spriteset settings
     {
@@ -2277,6 +2278,12 @@ void WL4EditorWindow::on_actionNew_Room_triggered()
 
     // Reset LevelHeader param
     CurrentLevel->GetLevelHeader()->NumOfMap++;
+
+    // set dirty
+    SetUnsavedChanges(true);
+    newRoom->SetEntityListDirty(0, true);
+    newRoom->SetEntityListDirty(1, true);
+    newRoom->SetEntityListDirty(2, true);
 
     // UI updates
     SetCurrentRoomId(newRoomId);

--- a/WL4EditorWindow.cpp
+++ b/WL4EditorWindow.cpp
@@ -2250,20 +2250,12 @@ void WL4EditorWindow::on_actionNew_Room_triggered()
         OutputWidget->PrintString(tr("Cannot add another Room to the current Level!"));
         return;
     }
-    int offset = WL4Constants::LevelHeaderIndexTable + selectedLevel._PassageIndex * 24 + selectedLevel._LevelIndex * 4;
-    int levelHeaderIndex = ROMUtils::IntFromData(offset);
-    int levelHeaderPointer = WL4Constants::LevelHeaderTable + levelHeaderIndex * 12;
-    int roomCount = ROMUtils::ROMFileMetadata->ROMDataPtr[levelHeaderPointer + 1];
-    unsigned int currentroomid = ui->spinBox_RoomID->value();
-    if (roomCount <= static_cast<int>(currentroomid))
-    {
-        OutputWidget->PrintString(tr("Cannot create room, current Room has not been saved to the ROM yet!"));
-        return;
-    }
 
-    int roomTableAddress = ROMUtils::PointerFromData(WL4Constants::RoomDataTable + CurrentLevel->GetLevelID() * 4);
-    CurrentLevel->AddRoom(new LevelComponents::Room(roomTableAddress + currentroomid * 0x2C, newRoomId, CurrentLevel->GetLevelID()));
-    LevelComponents::Room *newRoom = CurrentLevel->GetRooms()[newRoomId];
+    int entitysetId = GetCurrentRoom()->GetCurrentEntitySetID();
+    CurrentLevel->AddRoom(new LevelComponents::Room(newRoomId,
+                                                    CurrentLevel->GetLevelID(),
+                                                    GetCurrentRoom()->GetTilesetID(),
+                                                    entitysetId));
 
     // Add one Door to the new Room as well as spriteset settings
     {
@@ -2272,53 +2264,25 @@ void WL4EditorWindow::on_actionNew_Room_triggered()
         memset(&newDoorEntry, 0, sizeof(LevelComponents::__DoorEntry));
 
         // Initialize the fields
-        newDoorEntry.DoorTypeByte = (unsigned char) 2;
-        newDoorEntry.EntitySetID = (unsigned char) 1;
+        newDoorEntry.EntitySetID = entitysetId;
         newDoorEntry.RoomID = (unsigned char) newRoomId;
         newDoorEntry.DoorTypeByte = LevelComponents::DoorType::Instant;
         LevelComponents::Door *newDoor =
             new LevelComponents::Door(newDoorEntry, (unsigned char) newRoomId, CurrentLevel->GetDoors().size());
-        int entitysetId = CurrentLevel->GetRooms()[currentroomid]->GetCurrentEntitySetID();
-        newDoor->SetEntitySetID(entitysetId);
         newDoor->SetDestinationDoor(CurrentLevel->GetDoors()[0]);
 
-        // Add the new door to the Level object and re-render the screen
+        // Add the new door to the Level object
         CurrentLevel->AddDoor(newDoor);
-
-        // Set Current Entity list
-        newRoom->SetCurrentEntitySet(entitysetId);
     }
 
     // Reset LevelHeader param
     CurrentLevel->GetLevelHeader()->NumOfMap++;
 
-    // Reset pointers in RoomHeader to avoid save chunk invalidation corruption
-    // for regular layer chunk invalidation,
-    // the editor should check the RoomHeader instance from the Room instance to see if old layer data need to be invalidated.
-    // the RoomHeader should not be read as ref when creating layer chunks since new Room does not have RoomHeader in the ROM.
-    // those new mapping type 0x20 layer should save their layer pointer inside layer instance
-    QVector<int> offsetlist;
-    if(!(newRoom->GetLayer(0)->GetMappingType() & 0x20))
-    {
-        offsetlist << 0;
-    }
-    offsetlist << 1 << 2 << 5 << 6 << 7;
-    for(auto& _offset: offsetlist)
-    {
-        newRoom->SetRoomHeaderDataPtr(_offset, 0);
-    }
-    for(int i = offsetlist[0]; i < 3; i++)
-    {
-        newRoom->GetLayer(i)->SetDataPtr(0);
-    }
-    newRoom->SetCameraControlType(LevelComponents::__CameraControlType::NoLimit);
-
     // UI updates
     SetCurrentRoomId(newRoomId);
-    OutputWidget->PrintString(QString(tr("Created a new blank room")) + " (# 0x" + QString::number(newRoomId, 16) + ") " + tr("using the current room's data saved in the ROM."));
-
-    // Clear everything in the new room
-    ClearEverythingInRoom(true);
+    OutputWidget->PrintString(QString(tr("Created a new blank room")) +
+                              " (# 0x" + QString::number(newRoomId, 16) + ") " +
+                              tr("successfully using tileset and entityset from the current room."));
 }
 
 /// <summary>


### PR DESCRIPTION
- rewrite WL4EditorWindow::RoomConfigReset(...)
- fix Layer 0 mappingtype change from 0x2X to 0x1X cannot work
- now new Room can be created without using existing RoomHeader data from the ROM