### PR TITLE
Door Config Dialog UI tweak and animated Tile group graphical glitch fix 20230321

### DIFF
--- a/Dialog/DoorConfigDialog.cpp
+++ b/Dialog/DoorConfigDialog.cpp
@@ -52,7 +52,9 @@ DoorConfigDialog::DoorConfigDialog(QWidget *parent, LevelComponents::Room *curre
 
     // Initialize UI elements
     ui->ComboBox_DoorType->addItems(DoortypeSet);
-    LevelComponents::DoorEntry curDoorData = tmpDoorVec.GetDoor(tmpCurrentRoom->GetRoomID(), localDoorID);
+    int roomId = tmpCurrentRoom->GetRoomID();
+    LevelComponents::DoorEntry curDoorData = tmpDoorVec.GetDoor(roomId, localDoorID);
+    ui->label_CurrentDoorGlobalID->setText("0x" + QString::number(tmpDoorVec.GetGlobalIDByLocalID(roomId, localDoorID), 16));
     ui->ComboBox_DoorType->setCurrentIndex(curDoorData.DoorTypeByte - 1);
     ui->SpinBox_DoorX->setValue(curDoorData.x1);
     ui->SpinBox_DoorY->setValue(curDoorData.y1);

--- a/Dialog/DoorConfigDialog.ui
+++ b/Dialog/DoorConfigDialog.ui
@@ -364,6 +364,9 @@
         <string>Preview</string>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_5">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetDefaultConstraint</enum>
+        </property>
         <property name="bottomMargin">
          <number>3</number>
         </property>
@@ -390,6 +393,9 @@
            </property>
            <item>
             <layout class="QGridLayout" name="gridLayout_2">
+             <property name="spacing">
+              <number>0</number>
+             </property>
              <item row="0" column="0">
               <widget class="QLabel" name="Label_WarioX">
                <property name="sizePolicy">
@@ -454,19 +460,65 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="label_CurrentDoor">
+         <widget class="QFrame" name="frame_current_door">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="text">
-           <string>Current Door:</string>
+          <property name="frameShape">
+           <enum>QFrame::StyledPanel</enum>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
+          <property name="frameShadow">
+           <enum>QFrame::Raised</enum>
           </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_CurrentDoor">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Current Door global ID:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_CurrentDoorGlobalID">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </item>
         <item>

--- a/DockWidget/Tile16DockWidget.cpp
+++ b/DockWidget/Tile16DockWidget.cpp
@@ -129,8 +129,8 @@ void Tile16DockWidget::SetSelectedTile(unsigned short tile, bool resetscrollbar)
     int tmpTerrainTypeID = SelectedTileset->GetTerrainTypeIDTablePtr()[tile];
 
     // Print information about the tile to the user
-    QString infoText = tr("Tile ID: %1\nEvent ID (Hex): 0x%2\nTerrain type ID (Hex): 0x%3")
-                .arg(tile).arg(eventIndex, 4, 16, QChar('0'))
+    QString infoText = tr("Tile ID: 0x%1\nEvent ID (Hex): 0x%2\nTerrain type ID (Hex): 0x%3")
+                .arg(tile, 4, 16, QChar('0')).arg(eventIndex, 4, 16, QChar('0'))
                 .arg(tmpTerrainTypeID, 2, 16, QChar('0'));
     SetTileInfoText(infoText);
 

--- a/EditorWindow/MainGraphicsView.cpp
+++ b/EditorWindow/MainGraphicsView.cpp
@@ -242,6 +242,8 @@ void MainGraphicsView::mouseDoubleClickEvent(QMouseEvent *event) {
                                 // Apply changes
                                 // TODO: put the logic to the operation class to support Undo and Redo of Door things
                                 singleton->GetCurrentLevel()->SetDoorVec(_doorconfigdialog.GetChangedDoorVectorResult());
+                                auto doorsInRoom_new = singleton->GetCurrentLevel()->GetDoorListRef().GetDoorsByRoomID(room->GetRoomID());
+                                singleton->GetCurrentRoom()->SetCurrentEntitySet(doorsInRoom_new[i].EntitySetID);
                                 singleton->ResetEntitySetDockWidget();
                                 singleton->SetUnsavedChanges(true);
                             }

--- a/LevelComponents/LevelDoorVector.h
+++ b/LevelComponents/LevelDoorVector.h
@@ -70,7 +70,7 @@ namespace LevelComponents
         struct DoorEntry GetDestinationDoor(unsigned char roomID, unsigned char doorLocalId);
         QString GetDoorName(unsigned char doorGlobalId)
         {
-            return "Room 0x" + QString::number((int) doorvec[doorGlobalId].RoomID, 16) + " Door " + QString::number(doorGlobalId, 10);
+            return "Room 0x" + QString::number((int) doorvec[doorGlobalId].RoomID, 16) + " Door 0x" + QString::number(doorGlobalId, 16);
         }
         QVector<struct DoorEntry> GetDoorsByRoomID(unsigned char roomID);
         unsigned char GetLocalIDByGlobalID(unsigned char doorGlobalId);

--- a/LevelComponents/Tileset.cpp
+++ b/LevelComponents/Tileset.cpp
@@ -232,7 +232,12 @@ namespace LevelComponents
     /// </param>
     void Tileset::SetAnimatedTile(int tile8x8groupId, int tile8x8group2Id, int SwitchId, int startTile8x8Id)
     {
-        // TODO: Only save graphics from animated tile table 0 for now, need to load tiles from table 1 in the future. --ssp
+        // load the animated tile no. 0 will make the WL4Editor render some jank onto the Layer.
+        // we set the id to 1 to make it looks similar to the game's runetime vram
+        if (!tile8x8groupId) tile8x8groupId = 1;
+        if (!tile8x8group2Id) tile8x8group2Id = 1;
+
+        // Only load graphics from animated tile table 0 for now, we assume all the global switches in game are "off" by default. --ssp
         AnimatedTileData[0][startTile8x8Id >> 2] = tile8x8groupId;
         AnimatedTileData[1][startTile8x8Id >> 2] = tile8x8group2Id;
         AnimatedTileSwitchTable[startTile8x8Id >> 2] = SwitchId;

--- a/WL4EditorWindow.cpp
+++ b/WL4EditorWindow.cpp
@@ -180,6 +180,10 @@ void WL4EditorWindow::LoadRoomUIUpdate()
     ui->roomDecreaseButton->setEnabled(currentroomid);
     ui->roomIncreaseButton->setEnabled(CurrentLevel->GetRooms().size() > currentroomid + 1);
 
+    // Set the max and min for room id spinbox
+    ui->spinBox_RoomID->setMinimum(0);
+    ui->spinBox_RoomID->setMaximum(CurrentLevel->GetRooms().size() - 1);
+
     // Render the screen
     RenderScreenFull();
     SetEditModeDockWidgetLayerEditability();
@@ -412,18 +416,6 @@ void WL4EditorWindow::SetChangeCurrentRoomEnabled(bool state)
 /// </param>
 void WL4EditorWindow::SetCurrentRoomId(int roomid, bool call_from_spinbox_valuechange)
 {
-    bool illegal_input = false;
-    if (roomid == ui->spinBox_RoomID->value() && call_from_spinbox_valuechange == false)
-        illegal_input = true;
-    if(roomid < 0 || roomid >= static_cast<int>(CurrentLevel->GetRooms().size()))
-        illegal_input = true;
-    if (illegal_input && call_from_spinbox_valuechange)
-    {
-        QMessageBox::critical(this, tr("Error"), tr("Illegal Room ID !"));
-        ui->spinBox_RoomID->setValue(old_roomid_value);
-        return;
-    }
-
     // enable or disable those buttons
     if (!roomid)
         ui->roomDecreaseButton->setEnabled(false);
@@ -450,9 +442,6 @@ void WL4EditorWindow::SetCurrentRoomId(int roomid, bool call_from_spinbox_valuec
     Tile16SelecterWidget->SetTileset(tmpTilesetID);
     ResetEntitySetDockWidget();
     ResetCameraControlDockWidget();
-
-    // reserve the legal id
-    old_roomid_value = roomid;
 }
 
 /// <summary>

--- a/WL4EditorWindow.h
+++ b/WL4EditorWindow.h
@@ -45,7 +45,6 @@ private:
     QAction *RecentScripts[5];
     uint recentScriptNum = 0;
 
-    int old_roomid_value = 0; // only use this to set value when illegal input appear in the spinbox_RoomId
     uint graphicViewScalerate = 2;
     bool UnsavedChanges = false; // state check bool only be used when user try loading another ROM, another Level or
                                  // close the editor without saving changes


### PR DESCRIPTION
- show global door id for current Door, and display global door indexes using hex
- Fix Entity Selector dockwidget won't update after changes in Door Config Dialog being applied
- Fix graphical glitch on the first animated Tile group in Tileset and Room
- Show Tile ID by hex in Tile16 Selector dock widget
- Fix the Room ID spinbox cannot synchronize with buttons sometimes