### PR TITLE
Partial patch feature rewrite 20230419

### DIFF
--- a/AssortedGraphicUtils.cpp
+++ b/AssortedGraphicUtils.cpp
@@ -355,7 +355,7 @@ QString AssortedGraphicUtils::SaveAssortedGraphicsToROM(QVector<AssortedGraphicE
         // ChunkAllocator
 
         [&entries, &currentChunkId, &chunks, &hasDoneListChunk]
-        (unsigned char *TempFile, struct ROMUtils::FreeSpaceRegion freeSpace, struct ROMUtils::SaveData *sd, bool resetchunkIndex)
+        (unsigned char *TempFile, struct ROMUtils::FreeSpaceRegion freeSpace, struct ROMUtils::SaveData *sd, bool resetchunkIndex, int *require_size)
         {
             (void) TempFile;
 
@@ -383,6 +383,7 @@ QString AssortedGraphicUtils::SaveAssortedGraphicsToROM(QVector<AssortedGraphicE
                 if(chunks[currentChunkId].size > freeSpace.size - alignOffset - 12)
                 {
                     // This will request a larger free area
+                    *require_size = chunks[currentChunkId].size;
                     return ROMUtils::ChunkAllocationStatus::InsufficientSpace;
                 }
                 else
@@ -428,7 +429,8 @@ QString AssortedGraphicUtils::SaveAssortedGraphicsToROM(QVector<AssortedGraphicE
                     // To see if the data will fit, we must include the text contents, size of the RATS header, and one byte for versioning
                     if((unsigned int)assortedGraphicListChunkContents.length() + 13 > freeSpace.size)
                     {
-                        return ROMUtils::ChunkAllocationStatus::InsufficientSpace;
+                            *require_size = assortedGraphicListChunkContents.length() + 13;
+                            return ROMUtils::ChunkAllocationStatus::InsufficientSpace;
                     }
 
                     // Create the save chunk data

--- a/Dialog/PatchEditDialog.cpp
+++ b/Dialog/PatchEditDialog.cpp
@@ -20,7 +20,7 @@ static QRegularExpression  descriptionRegex("^[^;]+$");
 /// </summary>
 void PatchEditDialog::StaticComboBoxesInitialization()
 {
-    PatchTypeNameSet << "Binary" << "Assembly" << "C";
+    PatchTypeNameSet << "Binary" << "Assembly" << "C" << "C_dependency";
 }
 
 /// <summary>

--- a/Dialog/PatchManagerDialog.cpp
+++ b/Dialog/PatchManagerDialog.cpp
@@ -73,9 +73,17 @@ static QString GetPathRelativeToROM(const QString &filePath)
 {
     QDir ROMdir(ROMUtils::ROMFileMetadata->FilePath);
     ROMdir.cdUp();
-    if(filePath.startsWith(ROMdir.absolutePath()))
+    QString romfile_folder = ROMdir.absolutePath();
+    if(filePath.startsWith(romfile_folder))
     {
-        return filePath.right(filePath.length() - ROMdir.absolutePath().length() - 1);
+        if (romfile_folder.isEmpty())
+        {
+            return filePath.right(filePath.length());
+        }
+        else
+        {
+            return filePath.right(filePath.length() - romfile_folder.length() - 1);
+        }
     }
     else
     {
@@ -190,7 +198,7 @@ void PatchManagerDialog::on_addPatchButton_clicked()
     // Execute the edit dialog
     PatchEditDialog editDialog(this);
 
-retry:
+retry_add_patch:
     if(editDialog.exec() == QDialog::Accepted)
     {
         entry = editDialog.CreatePatchEntry();
@@ -198,7 +206,7 @@ retry:
         if(result != "")
         {
             QMessageBox::information(this, tr("About"), result);
-            goto retry;
+            goto retry_add_patch;
         }
         PatchTable->AddEntry(entry);
         ui->savePatchButton->setEnabled(true);
@@ -227,7 +235,7 @@ void PatchManagerDialog::on_editPatchButton_clicked()
         // Execute the edit dialog
         PatchEditDialog editDialog(this, selectedEntry);
 
-retry:
+retry_edit_patch:
         if(editDialog.exec() == QDialog::Accepted)
         {
             entry = editDialog.CreatePatchEntry();
@@ -235,7 +243,7 @@ retry:
             if(result != "")
             {
                 QMessageBox::information(this, tr("About"), result);
-                goto retry;
+                goto retry_edit_patch;
             }
             PatchTable->UpdateEntry(selectedIndex, entry);
             ui->savePatchButton->setEnabled(true);

--- a/Dialog/PatchManagerDialog.cpp
+++ b/Dialog/PatchManagerDialog.cpp
@@ -113,7 +113,7 @@ static QString ValidateNewEntry(QVector<struct PatchEntryItem> currentEntries, s
     }
 
     // Patch on the first 4 bytes of the rom is not allowed
-    if(newEntry.HookAddress < 4)
+    if(newEntry.HookAddress < 4 && newEntry.PatchType != C_dependency)
     {
         return QT_TR_NOOP("Patch on the first 4 bytes of the rom is not allowed.");
     }
@@ -156,7 +156,7 @@ static QString ValidateNewEntry(QVector<struct PatchEntryItem> currentEntries, s
         }
 
         // It does not make sense to add a save chunk with no link to it in the hook
-        if(newEntry.PatchOffsetInHookString == (unsigned int) -1)
+        if(newEntry.PatchOffsetInHookString == (unsigned int) -1 && newEntry.PatchType != C_dependency)
         {
             return QT_TR_NOOP("A file is sepcified, so a save chunk will be created. But, the hook does not specify the P identifier for the patch code address. The save chunk would be useless, so this is not allowed (please use P in the hook).");
         }

--- a/Dialog/PatchManagerDialog.cpp
+++ b/Dialog/PatchManagerDialog.cpp
@@ -118,6 +118,22 @@ static QString ValidateNewEntry(QVector<struct PatchEntryItem> currentEntries, s
         return QT_TR_NOOP("Patch on the first 4 bytes of the rom is not allowed.");
     }
 
+    // special cases for "C_dependency" type patches
+    if (newEntry.PatchType == C_dependency)
+    {
+        // not allowed to set HookAddress
+        if(newEntry.HookAddress)
+        {
+            return QT_TR_NOOP("It is not allowed to set HookAddress for C_dependency type patches.");
+        }
+
+        // not allowed to set HookString
+        if(!newEntry.HookString.isEmpty())
+        {
+            return QT_TR_NOOP("It is not allowed to set HookString for C_dependency type patches.");
+        }
+    }
+
     // File name may not contain a semicolon
     if(newEntry.FileName.contains(";"))
     {

--- a/Dialog/PatchManagerTableView.cpp
+++ b/Dialog/PatchManagerTableView.cpp
@@ -65,11 +65,12 @@ void PatchManagerTableView::UpdateTableView()
     // Populate the table items
     for(const struct PatchEntryItem &patchEntry : EntryTableModel.entries)
     {
-        const char *typeStrings[3] =
+        const char *typeStrings[4] =
         {
             "Binary",
             "Assembly",
-            "C"
+            "C",
+            "C_dependency"
         };
         if(patchEntry.PatchType >= sizeof(typeStrings) / sizeof(typeStrings[0]))
         {
@@ -81,12 +82,10 @@ void PatchManagerTableView::UpdateTableView()
         QVector<QStandardItem*> items;
         items.append(new QStandardItem(patchEntry.FileName.length() ? patchEntry.FileName : "(no file)"));
         items.append(new QStandardItem(QString(typeStrings[patchEntry.PatchType])));
-        items.append(new QStandardItem("0x" + QString::number(patchEntry.HookAddress, 16).toUpper()));
-        QString PatchAddressString = !patchEntry.PatchAddress ?
-                    "N/A" : "0x" + QString::number(patchEntry.PatchAddress + 12, 16).toUpper();
-        PatchAddressString = (patchEntry.PatchAddress == DummyPatchAddressValue) ?
-                    "TBD" :
-                    PatchAddressString;
+        QString HookAddressString = (!patchEntry.HookAddress ? "N/A" : ("0x" + QString::number(patchEntry.HookAddress, 16).toUpper()));
+        items.append(new QStandardItem(HookAddressString));
+        QString PatchAddressString = !patchEntry.PatchAddress ? "N/A" : "0x" + QString::number(patchEntry.PatchAddress + 12, 16).toUpper();
+        PatchAddressString = (patchEntry.PatchAddress == DummyPatchAddressValue) ? "TBD" : PatchAddressString;
         items.append(new QStandardItem(PatchAddressString));
         QString finalHookStringText = patchEntry.HookString;
         if (patchEntry.PatchOffsetInHookString != (unsigned int) -1)

--- a/FileIOUtils.h
+++ b/FileIOUtils.h
@@ -1,6 +1,7 @@
 ﻿#ifndef FILEIOUTILS_H
 #define FILEIOUTILS_H
 
+#include <map>
 #include <QVector>
 #include <QColor>
 #include <QImage>
@@ -21,6 +22,7 @@ namespace FileIOUtils
 
     // patch parser stuff
     QString GetParamFromSourceFile(QString filePath, QString identifier, QRegularExpression validator);
+    bool GetGlobalSymbolsFromSourceFile(QString txtfilepath, std::map<unsigned int, QString>& gConsts, std::map<unsigned int, QString>& gFunctions);
     unsigned int FindEntryFunctionAddress(QString txtfilePath, QString entryFunctionSymbol = "");
 
     // helper functions

--- a/PatchUtils.cpp
+++ b/PatchUtils.cpp
@@ -812,11 +812,9 @@ namespace PatchUtils
                         // Allocation success
                         *sd = saveData;
 
-                        // Advance patch iterator to next non-hex-edit patch
+                        // Advance patch iterator to the next C_dependency patch
                         dependencyPatchFileAllocIter++;
-                        while(dependencyPatchFileAllocIter != entries.end() &&
-                               (dependencyPatchFileAllocIter->PatchType != C_dependency) &&
-                               !dependencyPatchFileAllocIter->FileName.length())
+                        while(dependencyPatchFileAllocIter != entries.end() && (dependencyPatchFileAllocIter->PatchType != C_dependency))
                         {
                             dependencyPatchFileAllocIter++;
                         }
@@ -873,11 +871,11 @@ namespace PatchUtils
                         // Allocation success
                         *sd = saveData;
 
-                        // Advance patch iterator to next non-hex-edit patch
+                        // Advance patch iterator to the next non-C_dependency patch
                         regularPatchFileAllocIter++;
                         while(regularPatchFileAllocIter != entries.end() &&
-                               (regularPatchFileAllocIter->PatchType == C_dependency) &&
-                               !regularPatchFileAllocIter->FileName.length())
+                               !regularPatchFileAllocIter->FileName.length() &&
+                               (dependencyPatchFileAllocIter->PatchType != C_dependency))
                         {
                             regularPatchFileAllocIter++;
                         }

--- a/PatchUtils.h
+++ b/PatchUtils.h
@@ -5,19 +5,20 @@
 
 enum PatchType
 {
-    Binary   = 0,
-    Assembly = 1,
-    C        = 2
+    Binary       = 0,
+    Assembly     = 1,
+    C            = 2,
+    C_dependency = 3
 };
 
 struct PatchEntryItem
 {
     QString FileName;
     enum PatchType PatchType;
-    unsigned int HookAddress;
+    unsigned int HookAddress;             // where to overwrite hookstring
     QString HookString;
-    unsigned int PatchOffsetInHookString;
-    unsigned int PatchAddress;
+    unsigned int PatchOffsetInHookString; // where the P is in the hookstring
+    unsigned int PatchAddress;            // where the patch we insert into the ROM
     QString SubstitutedBytes;
     QString Description;
 

--- a/ROMUtils.h
+++ b/ROMUtils.h
@@ -120,7 +120,7 @@ namespace ROMUtils
     QVector<unsigned int> FindAllChunksInROM(unsigned char *ROMData, unsigned int ROMLength, unsigned int startAddr, enum SaveDataChunkType chunkType, bool anyChunk = false);
 
     bool SaveFile(QString filePath, QVector<unsigned int> invalidationChunks,
-        std::function<ChunkAllocationStatus (unsigned char*, struct FreeSpaceRegion, struct SaveData*, bool)> ChunkAllocator,
+        std::function<ChunkAllocationStatus (unsigned char*, struct FreeSpaceRegion, struct SaveData*, bool, int*)> ChunkAllocator,
         std::function<QString (unsigned char*, std::map<int, int>)> PostProcessingCallback);
     bool SaveLevel(QString fileName);
 

--- a/WL4Editor.pro
+++ b/WL4Editor.pro
@@ -35,6 +35,7 @@ QMAKE_CXXFLAGS = -fpermissive
 msvc* {
 QMAKE_CXXFLAGS += /Zc:__cplusplus
 QMAKE_CXXFLAGS += /permissive-
+QMAKE_CXXFLAGS += /MP
 }
 
 SOURCES += \


### PR DESCRIPTION
Optimize the asm and C patch compile and save logic to make it faster for Patch Manager,
Faster free space offering logic for every type of save process.
Fix a single one Binary patch entry cannot be loaded after save in the Patch Manager
Fix the first letter of the path string of every patch file will be removed from the PatchList data if the rom file is naked on the drive in Patch Manager Dialog
Support "C_dependency" patch type in Patch Manager Dialog
Close #438  