### PR TITLE
add missing logic in the save data part for Wall Paint Editor 20230620

### DIFF
--- a/Dialog/WallPaintEditorDialog.cpp
+++ b/Dialog/WallPaintEditorDialog.cpp
@@ -72,14 +72,19 @@ void WallPaintEditorDialog::AcceptChanges()
         unsigned int addr = ROMUtils::PointerFromData(WL4Constants::WallPaintPalSixInOneMMapColorPtrTable + 4 * passage);
         for (int level = 0; level < 4; level++)
         {
+            // copy MMAP gradient palettes for regular level
             unsigned int startlevel_paladdr = GetGradPalStartAddr(passage, level);
             if (!startlevel_paladdr) continue;
             memcpy(&(ROMUtils::ROMFileMetadata->ROMDataPtr[startlevel_paladdr]), pal_startlevel_color + passage * 4 * (32 * 8) + level * (32 * 8), 32 * 8);
 
+            // copy MMAP palette for regular level
             memcpy(&(ROMUtils::ROMFileMetadata->ROMDataPtr[addr + 32 * (0xA + level)]),
                    pal_passage_color + 32 * 5 * passage + 32 * level,
                    32);
         }
+
+        // copy MMAP palette for boss level
+        memcpy(&(ROMUtils::ROMFileMetadata->ROMDataPtr[addr + 32 * (0xA + 4)]), pal_passage_color + 32 * 5 * passage + 32 * 4, 32);
     }
 }
 

--- a/Dialog/WallPaintEditorDialog.cpp
+++ b/Dialog/WallPaintEditorDialog.cpp
@@ -69,11 +69,16 @@ void WallPaintEditorDialog::AcceptChanges()
     memcpy(&(ROMUtils::ROMFileMetadata->ROMDataPtr[WL4Constants::WallPaintPalPassageGray]), pal_passage_gray, sizeof(pal_passage_gray));
     for (int passage = 0; passage < 6; passage++)
     {
+        unsigned int addr = ROMUtils::PointerFromData(WL4Constants::WallPaintPalSixInOneMMapColorPtrTable + 4 * passage);
         for (int level = 0; level < 4; level++)
         {
             unsigned int startlevel_paladdr = GetGradPalStartAddr(passage, level);
             if (!startlevel_paladdr) continue;
             memcpy(&(ROMUtils::ROMFileMetadata->ROMDataPtr[startlevel_paladdr]), pal_startlevel_color + passage * 4 * (32 * 8) + level * (32 * 8), 32 * 8);
+
+            memcpy(&(ROMUtils::ROMFileMetadata->ROMDataPtr[addr + 32 * (0xA + level)]),
+                   pal_passage_color + 32 * 5 * passage + 32 * level,
+                   32);
         }
     }
 }

--- a/WL4Constants.h
+++ b/WL4Constants.h
@@ -36,10 +36,11 @@ namespace WL4Constants
     const unsigned int CreditsTiles                = 0x789FCC;
 
     // Wall Paint GFX and Palettes
-    const unsigned int WallPaintGFXAddr                   = 0x64C8C4;
-    const unsigned int WallPaintPalPassageColor           = 0x6A0A48;
-    const unsigned int WallPaintPalPassageGray            = 0x6A0E08;
-    const unsigned int WallPaintPalStartLevelPointerTable = 0x63A25C;
+    const unsigned int WallPaintGFXAddr                      = 0x64C8C4;
+    const unsigned int WallPaintPalPassageColor              = 0x6A0A48;
+    const unsigned int WallPaintPalPassageGray               = 0x6A0E08;
+    const unsigned int WallPaintPalStartLevelPointerTable    = 0x63A25C;
+    const unsigned int WallPaintPalSixInOneMMapColorPtrTable = 0x63A244;
 
     // Other
     const unsigned int AvailableSpaceBeginningInROM = 0x78F970;


### PR DESCRIPTION
Fix Wall Paint Editor misses a part of data saving logic which causes incorrect palette loading in mmap scene when replaying a level